### PR TITLE
ANS-83: Refactored examples to use collection action names.

### DIFF
--- a/examples/PlaybookGeneration.yaml
+++ b/examples/PlaybookGeneration.yaml
@@ -1,12 +1,9 @@
-- hosts: all
-  name: "Create a10_slb_virtual_server_port example playbook"
+- hosts: "{{desired_inventory_group}}"
+  name: "Create a10.acos_axapi.a10_slb_virtual_server_port example playbook"
   connection: local
   tasks:
   - name: Create playbooks 
-    a10_playbook_generator:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+    a10.acos_axapi.a10_playbook_generator:
       state: present
       output_path: "~/newplays"
       file_per_task: False

--- a/examples/scenario/glm/request_glm_license.yaml
+++ b/examples/scenario/glm/request_glm_license.yaml
@@ -1,23 +1,13 @@
 - name: Add a glm license example 
   connection: local
-  hosts: all 
+  hosts: "{{desired_inventory_group}}" 
   tasks:
   - name: Authenticate via token
-    a10_glm:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_protocol: "{{ a10_protocol }}"
-      a10_port: "{{ a10_port }}"
+    a10.acos_axapi.a10_glm:
       token: "EXAMPLE_TOKEN"
       use_mgmt_port: 0
   - name: Request license
-    a10_glm:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_protocol: "{{ a10_protocol }}"
-      a10_port: "{{ a10_port }}"
+    a10.acos_axapi.a10_glm:
       use_mgmt_port: 0
       send:
         license-request: 1

--- a/examples/scenario/slb/client_ssl_template_create.yaml
+++ b/examples/scenario/slb/client_ssl_template_create.yaml
@@ -1,6 +1,6 @@
-- hosts: "{{desired_inventory_group}}"
+- name: Create a10.acos_axapi.a10_slb_template_client_ssl example playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
-  name: "My thing"
   tasks:
   - name: "Create ssl cert "
     a10.acos_axapi.a10_slb_template_client_ssl:

--- a/examples/scenario/slb/client_ssl_template_create.yaml
+++ b/examples/scenario/slb/client_ssl_template_create.yaml
@@ -1,14 +1,9 @@
-- hosts: all
+- hosts: "{{desired_inventory_group}}"
   connection: local
   name: "My thing"
   tasks:
   - name: "Create ssl cert "
-    a10_slb_template_client_ssl:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+    a10.acos_axapi.a10_slb_template_client_ssl:
       name: client_ssl
       cert: mycert
       key: mykey

--- a/examples/scenario/slb/health_monitor_method.yaml
+++ b/examples/scenario/slb/health_monitor_method.yaml
@@ -1,14 +1,9 @@
-- name: Create a10_health_motnitor example playbook
+- name: Create a10.acos_axapi.a10_health_motnitor example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_health_monitor instance
-    a10_health_monitor:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: {{ a10_port }}
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_health_monitor instance
+    a10.acos_axapi.a10_health_monitor:
       name: tcp_443
       method:
         tcp:

--- a/examples/scenario/slb/lb_graph_create_update.yaml
+++ b/examples/scenario/slb/lb_graph_create_update.yaml
@@ -1,59 +1,34 @@
-- hosts: all
-  name: "Create a10_slb_virtual_server_port example playbook"
+- hosts: "{{desired_inventory_group}}"
+  name: "Create a10.acos_axapi.a10_slb_virtual_server_port example playbook"
   connection: local
   tasks:
   - name: Create service group
-    a10_slb_service_group:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol": "{{ a10_protocol }}"
+    a10.acos_axapi.a10_slb_service_group:
       name: sg1
       protocol: "tcp"
       lb_method: "weighted-rr"
 
   - name: Associate member server
-    a10_slb_service_group_member:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol": "{{ a10_protocol }}"
+    a10.acos_axapi.a10_slb_service_group_member:
       name: server1
       host: "10.20.20.2"
       service_group: sg1
       port: 80
 
-  - name: Create a10_slb_virtual_server instance
-    a10_slb_virtual_server:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol": "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_slb_virtual_server instance
+    a10.acos_axapi.a10_slb_virtual_server:
       ip_address: 192.168.42.1
       netmask: 255.255.255.0
       name: vs1
 
-  - name: Create a10_slb_virtual_server_port instance
-    a10_slb_virtual_server_port:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol": "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_slb_virtual_server_port instance
+    a10.acos_axapi.a10_slb_virtual_server_port:
       virtual_server: vs1
       protocol: "tcp"
       port_number: 80
 
   - name: Create another port
-    a10_slb_virtual_server_port:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{a10_username}}"
-      a10_password: "{{a10_password}}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol": "{{ a10_protocol }}"
+    a10.acos_axapi.a10_slb_virtual_server_port:
       virtual_server: vs1
       protocol: "tcp"
       port_number: 81

--- a/examples/scenario/slb/lb_graph_delete.yaml
+++ b/examples/scenario/slb/lb_graph_delete.yaml
@@ -1,35 +1,20 @@
-- name: Delete a10_slb_virtual_server example playbook
+- name: Delete a10.acos_axapi.a10_slb_virtual_server example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_vport
-    a10_slb_virtual_server_port:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol": "{{a10_protocol }}"
+  - name: Delete a10.acos_axapi.a10_slb_vport
+    a10.acos_axapi.a10_slb_virtual_server_port:
       state: absent
       virtual_server: vs1
       port_number: 80
       protocol: tcp
 
-  - name: Delete a10_slb_virtual_server instance
-    a10_slb_virtual_server:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol": "{{ a10_protocol }}"
+  - name: Delete a10.acos_axapi.a10_slb_virtual_server instance
+    a10.acos_axapi.a10_slb_virtual_server:
       state: absent
       name: vs1
 
   - name: Delete sg
-    a10_slb_service_group:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol": "{{a10_protocol }}"
+    a10.acos_axapi.a10_slb_service_group:
       state: absent
       name:  sg1

--- a/examples/scenario/slb/ssl_cert_create.yaml
+++ b/examples/scenario/slb/ssl_cert_create.yaml
@@ -1,6 +1,6 @@
-- hosts: "{{desired_inventory_group}}"
+- name: Create a10.acos_axapi.a10_file_ssl_cert example playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
-  name: "My thing"
   tasks:
   - name: "Create ssl cert "
     a10.acos_axapi.a10_file_ssl_cert:

--- a/examples/scenario/slb/ssl_cert_create.yaml
+++ b/examples/scenario/slb/ssl_cert_create.yaml
@@ -1,14 +1,9 @@
-- hosts: all
+- hosts: "{{desired_inventory_group}}"
   connection: local
   name: "My thing"
   tasks:
   - name: "Create ssl cert "
-    a10_file_ssl_cert:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+    a10.acos_axapi.a10_file_ssl_cert:
       file: mycert
       certificate_type: pem
       file_content: "{{lookup('file', '~/certs/new.cert.cert')}}"

--- a/examples/scenario/slb/ssl_key_create.yaml
+++ b/examples/scenario/slb/ssl_key_create.yaml
@@ -1,6 +1,6 @@
-- hosts: "{{desired_inventory_group}}"
+- name: Create a10.acos_axapi.a10_file_ssl_key example playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
-  name: "My thing"
   tasks:
   - name: "Create ssl cert "
     a10.acos_axapi.a10_file_ssl_key:

--- a/examples/scenario/slb/ssl_key_create.yaml
+++ b/examples/scenario/slb/ssl_key_create.yaml
@@ -1,13 +1,8 @@
-- hosts: all
+- hosts: "{{desired_inventory_group}}"
   connection: local
   name: "My thing"
   tasks:
   - name: "Create ssl cert "
-    a10_file_ssl_key:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_protocol: "{{ a10_protocol }}"
-      a10_port: "{{ a10_port }}"
+    a10.acos_axapi.a10_file_ssl_key:
       file: myxc
       file_content: "{{lookup('file', '~/certs/new.cert.key')}}"

--- a/examples/scenario/slb/template_ftp_create.yaml
+++ b/examples/scenario/slb/template_ftp_create.yaml
@@ -1,14 +1,9 @@
 
 
-- name: Create a10_slb_template_ftp example playbook
+- name: Create a10.acos_axapi.a10_slb_template_ftp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_ftp instance
-    a10_slb_template_ftp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol": "{{a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_slb_template_ftp instance
+    a10.acos_axapi.a10_slb_template_ftp:
       name: my_ftp

--- a/examples/scenario/slb/template_tcp_create.yaml
+++ b/examples/scenario/slb/template_tcp_create.yaml
@@ -1,21 +1,16 @@
 
 
-- name: Create a10_slb_template_tcp example playbook
+- name: Create a10.acos_axapi.a10_slb_template_tcp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_tcp instance
-    a10_slb_template_tcp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol": "{{a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_slb_template_tcp instance
+    a10.acos_axapi.a10_slb_template_tcp:
       name: session-aging-5min
       idle_timeout: 300
 
-  - name: Create a10_slb_template_tcp_proxy
-    a10_slb_template_tcp_proxy:
+  - name: Create a10.acos_axapi.a10_slb_template_tcp_proxy
+    a10.acos_axapi.a10_slb_template_tcp_proxy:
       idle_timeout: 300
       reset_fwd: True
       reset_rev: True

--- a/examples/scenario/slb/template_tcp_proxy_create.yaml
+++ b/examples/scenario/slb/template_tcp_proxy_create.yaml
@@ -1,16 +1,11 @@
 
 
-- name: Create a10_slb_template_tcp_proxy example playbook
+- name: Create a10.acos_axapi.a10_slb_template_tcp_proxy example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_tcp_proxy instance
-    a10_slb_template_tcp_proxy:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol": "{{a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_slb_template_tcp_proxy instance
+    a10.acos_axapi.a10_slb_template_tcp_proxy:
       name: default
       ack_aggressiveness: low
       fin_timeout: 1
@@ -24,18 +19,13 @@
       timewait: 1
       invalid_rate_limit: 0
 
-- name: Update a10_slb_template_tcp_proxy example playbook
+- name: Update a10.acos_axapi.a10_slb_template_tcp_proxy example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_tcp_proxy instance
-    a10_slb_template_tcp_proxy:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_slb_template_tcp_proxy instance
+    a10.acos_axapi.a10_slb_template_tcp_proxy:
       state: present
-      a10_port: "{{ a10_port }}"
-      a10_protocol": "{{a10_protocol }}"
       name: default
       ack_aggressiveness: low
       fin_timeout: 1
@@ -49,17 +39,12 @@
       timewait: 1
       invalid_rate_limit: 0
 
-- name: Delete a10_slb_template_tcp_proxy example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_tcp_proxy example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_tcp_proxy instance
-    a10_slb_template_tcp_proxy:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol": "{{a10_protocol }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_tcp_proxy instance
+    a10.acos_axapi.a10_slb_template_tcp_proxy:
       state: absent
       name: default
       ack_aggressiveness: low

--- a/examples/scenario/slb/template_tcp_proxy_delete.yaml
+++ b/examples/scenario/slb/template_tcp_proxy_delete.yaml
@@ -1,14 +1,9 @@
-- name: Delete a10_slb_template_tcp_proxy example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_tcp_proxy example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_tcp_proxy instance
-    a10_slb_template_tcp_proxy:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol": "{{a10_protocol }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_tcp_proxy instance
+    a10.acos_axapi.a10_slb_template_tcp_proxy:
       state: absent
       name: default
       ack_aggressiveness: low

--- a/examples/scenario/slb/template_tcp_proxy_update.yaml
+++ b/examples/scenario/slb/template_tcp_proxy_update.yaml
@@ -1,15 +1,10 @@
-- name: Update a10_slb_template_tcp_proxy example playbook
+- name: Update a10.acos_axapi.a10_slb_template_tcp_proxy example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_tcp_proxy instance
-    a10_slb_template_tcp_proxy:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_slb_template_tcp_proxy instance
+    a10.acos_axapi.a10_slb_template_tcp_proxy:
       state: present
-      a10_port: "{{ a10_port }}"
-      a10_protocol": "{{a10_protocol }}"
       name: default
       ack_aggressiveness: low
       fin_timeout: 1

--- a/examples/single_task/admin/adminGlobal/a10_admin_global_create.yml
+++ b/examples/single_task/admin/adminGlobal/a10_admin_global_create.yml
@@ -1,14 +1,9 @@
-- name: a10_admin_global_create Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_admin_global_create Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_admin
-    a10_admin:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_admin
+    a10.acos_axapi.a10_admin:
       state: "present"
       privilege_global: "write"
       trusted_host: "false"

--- a/examples/single_task/admin/adminGlobal/a10_admin_global_delete.yml
+++ b/examples/single_task/admin/adminGlobal/a10_admin_global_delete.yml
@@ -1,14 +1,9 @@
-- name: a10_admin_global_delete Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_admin_global_delete Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_admin
-    a10_admin:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_admin
+    a10.acos_axapi.a10_admin:
       state: "absent"
       privilege_global: "write"
       trusted_host: "false"

--- a/examples/single_task/admin/adminGlobal/a10_admin_global_update.yml
+++ b/examples/single_task/admin/adminGlobal/a10_admin_global_update.yml
@@ -1,14 +1,9 @@
-- name: a10_admin_global_update Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_admin_global_update Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_admin
-    a10_admin:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_admin
+    a10.acos_axapi.a10_admin:
       state: "present"
       privilege_global: "write"
       trusted_host: "false"

--- a/examples/single_task/admin/adminPartition/a10_admin_partition_create.yml
+++ b/examples/single_task/admin/adminPartition/a10_admin_partition_create.yml
@@ -1,14 +1,9 @@
-- name: a10_admin_partition_create Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_admin_partition_create Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_admin
-    a10_admin:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_admin
+    a10.acos_axapi.a10_admin:
       state: "present"
       trusted_host: "false"
       user: "admin"

--- a/examples/single_task/admin/adminPartition/a10_admin_partition_delete.yml
+++ b/examples/single_task/admin/adminPartition/a10_admin_partition_delete.yml
@@ -1,14 +1,9 @@
-- name: a10_admin_partition_delete Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_admin_partition_delete Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_admin
-    a10_admin:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_admin
+    a10.acos_axapi.a10_admin:
       state: "absent"
       trusted_host: "false"
       user: "admin"

--- a/examples/single_task/admin/adminPartition/a10_admin_partition_update.yml
+++ b/examples/single_task/admin/adminPartition/a10_admin_partition_update.yml
@@ -1,14 +1,9 @@
-- name: a10_admin_partition_update Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_admin_partition_update Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_admin
-    a10_admin:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_admin
+    a10.acos_axapi.a10_admin:
       state: "present"
       trusted_host: "false"
       user: "admin"

--- a/examples/single_task/admin/adminPrivileges/a10_admin_global_read.yml
+++ b/examples/single_task/admin/adminPrivileges/a10_admin_global_read.yml
@@ -1,14 +1,9 @@
-- name: a10_admin_global_read Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_admin_global_read Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_admin
-    a10_admin:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_admin
+    a10.acos_axapi.a10_admin:
       state: "present"
       trusted_host: "false"
       user: "admin"

--- a/examples/single_task/admin/adminPrivileges/a10_admin_global_write.yml
+++ b/examples/single_task/admin/adminPrivileges/a10_admin_global_write.yml
@@ -1,14 +1,9 @@
-- name: a10_admin_global_write Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_admin_global_write Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_admin
-    a10_admin:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_admin
+    a10.acos_axapi.a10_admin:
       state: "present"
       trusted_host: "false"
       user: "admin"

--- a/examples/single_task/admin/adminPrivileges/a10_admin_partition_read.yml
+++ b/examples/single_task/admin/adminPrivileges/a10_admin_partition_read.yml
@@ -1,14 +1,9 @@
-- name: a10_admin_partition_read_privilege Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_admin_partition_read_privilege Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_admin
-    a10_admin:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_admin
+    a10.acos_axapi.a10_admin:
       state: "present" 
       trusted_host: "false"
       user: "admin"

--- a/examples/single_task/admin/adminPrivileges/a10_admin_partition_write.yml
+++ b/examples/single_task/admin/adminPrivileges/a10_admin_partition_write.yml
@@ -1,14 +1,9 @@
-- name: a10_admin_partition_write_privilege Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_admin_partition_write_privilege Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_admin
-    a10_admin:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_admin
+    a10.acos_axapi.a10_admin:
       state: "present" 
       trusted_host: "false"
       user: "admin"

--- a/examples/single_task/backup/a10_backup_log.yml
+++ b/examples/single_task/backup/a10_backup_log.yml
@@ -1,12 +1,7 @@
 - name: Example playbook to backup log files 
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
   - name: Backup log files 
-    a10_backup_log:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+    a10.acos_axapi.a10_backup_log:
       remote_file: "scp://username:password@host:/path/to/file"

--- a/examples/single_task/backup/a10_backup_system.yml
+++ b/examples/single_task/backup/a10_backup_system.yml
@@ -1,12 +1,7 @@
 - name: Example playbook to backup system files
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
   - name: Backup system files
-    a10_backup_system:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+    a10.acos_axapi.a10_backup_system:
       remote_file: "scp://username:password@host:/path/to/file"

--- a/examples/single_task/bootimage/a10_bootimage.yaml
+++ b/examples/single_task/bootimage/a10_bootimage.yaml
@@ -1,14 +1,9 @@
 - name: Change Boot Image example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: a10_bootimage instance
-    a10_bootimage:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_bootimage instance
+    a10.acos_axapi.a10_bootimage:
       hd_cfg:
         pri: 1
         sec: 1

--- a/examples/single_task/cgnv6/a10_cgnv6_ecmp.yml
+++ b/examples/single_task/cgnv6/a10_cgnv6_ecmp.yml
@@ -1,12 +1,7 @@
-- name: a10_cgnv6_ecmp example playbook
+- name: a10.acos_axapi.a10_cgnv6_ecmp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: a10_cgnv6_ecmp
-    a10_cgnv6_ecmp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_ecmp
+    a10.acos_axapi.a10_cgnv6_ecmp:
       hashing_type: "4-tuple-hash"

--- a/examples/single_task/cgnv6/a10_cgnv6_global.yml
+++ b/examples/single_task/cgnv6/a10_cgnv6_global.yml
@@ -1,13 +1,8 @@
-- name: a10_cgnv6_global example playbook
+- name: a10.acos_axapi.a10_cgnv6_global example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: a10_cgnv6_global
-    a10_cgnv6_global:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_global
+    a10.acos_axapi.a10_cgnv6_global:
       sampling_enable:
         - counters1: "all"

--- a/examples/single_task/cgnv6/a10_cgnv6_http_alg.yml
+++ b/examples/single_task/cgnv6/a10_cgnv6_http_alg.yml
@@ -1,13 +1,8 @@
-- name: a10_cgnv6_http_alg example playbook
+- name: a10.acos_axapi.a10_cgnv6_http_alg example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: a10_cgnv6_http_alg
-    a10_cgnv6_http_alg:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_http_alg
+    a10.acos_axapi.a10_cgnv6_http_alg:
       sampling_enable:
         - counters1: "all"

--- a/examples/single_task/cgnv6/a10_cgnv6_icmp.yml
+++ b/examples/single_task/cgnv6/a10_cgnv6_icmp.yml
@@ -1,13 +1,8 @@
-- name: a10_cgnv6_icmp example playbook
+- name: a10.acos_axapi.a10_cgnv6_icmp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: a10_cgnv6_icmp
-    a10_cgnv6_icmp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_icmp
+    a10.acos_axapi.a10_cgnv6_icmp:
       sampling_enable:
         - counters1: "all"

--- a/examples/single_task/cgnv6/a10_cgnv6_l4.yml
+++ b/examples/single_task/cgnv6/a10_cgnv6_l4.yml
@@ -1,13 +1,8 @@
-- name: a10_cgnv6_l4 example playbook
+- name: a10.acos_axapi.a10_cgnv6_l4 example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: a10_cgnv6_l4
-    a10_cgnv6_l4:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_l4
+    a10.acos_axapi.a10_cgnv6_l4:
       sampling_enable:
         - counters1: "all"

--- a/examples/single_task/cgnv6/a10_cgnv6_pcp.yml
+++ b/examples/single_task/cgnv6/a10_cgnv6_pcp.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_pcp
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_pcp
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_pcp
-    a10_cgnv6_pcp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_pcp
+    a10.acos_axapi.a10_cgnv6_pcp:
       state: "present"
       sampling_enable:
         - counters1: "all"

--- a/examples/single_task/cgnv6/a10_cgnv6_shared_service_group.yml
+++ b/examples/single_task/cgnv6/a10_cgnv6_shared_service_group.yml
@@ -1,13 +1,8 @@
-- name: a10_cgnv6_shared_service_group Example Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_shared_service_group Example Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_shared_service_group
-    a10_cgnv6_shared_service_group:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_shared_service_group
+    a10.acos_axapi.a10_cgnv6_shared_service_group:
       state: "present"
       get_type: "single"      

--- a/examples/single_task/cgnv6/ddos_protection/a10_cgnv6_ddos_protection.yml
+++ b/examples/single_task/cgnv6/ddos_protection/a10_cgnv6_ddos_protection.yml
@@ -1,15 +1,10 @@
-- name: a10_cgnv6_ddos_protection Example Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_ddos_protection Example Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_ddos_protection
-    a10_cgnv6_ddos_protection:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: a10.acos_axapi.a10_cgnv6_ddos_protection
+    a10.acos_axapi.a10_cgnv6_ddos_protection:
       state: "present"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
       logging: 
         logging_toggle: "enable"
       zone: "zone1"

--- a/examples/single_task/cgnv6/ddos_protection/a10_cgnv6_ddos_protection_disable_nat_ip_by_bgp.yml
+++ b/examples/single_task/cgnv6/ddos_protection/a10_cgnv6_ddos_protection_disable_nat_ip_by_bgp.yml
@@ -1,12 +1,7 @@
-- name: a10_cgnv6_ddos_protection_disable_nat_ip_by_bgp
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_ddos_protection_disable_nat_ip_by_bgp
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_ddos_protection_disable_nat_ip_by_bgp
-    a10_cgnv6_ddos_protection_disable_nat_ip_by_bgp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: a10.acos_axapi.a10_cgnv6_ddos_protection_disable_nat_ip_by_bgp
+    a10.acos_axapi.a10_cgnv6_ddos_protection_disable_nat_ip_by_bgp:
       state: "present"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"      

--- a/examples/single_task/cgnv6/ddos_protection/a10_cgnv6_ddos_protection_ip_entries.yml
+++ b/examples/single_task/cgnv6/ddos_protection/a10_cgnv6_ddos_protection_ip_entries.yml
@@ -1,12 +1,7 @@
-- name: a10_cgnv6_ddos_protection_ip_entries
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_ddos_protection_ip_entries
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_ddos_protection_ip_entries
-    a10_cgnv6_ddos_protection_ip_entries:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: a10.acos_axapi.a10_cgnv6_ddos_protection_ip_entries
+    a10.acos_axapi.a10_cgnv6_ddos_protection_ip_entries:
       state: "present"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"

--- a/examples/single_task/cgnv6/ddos_protection/a10_cgnv6_ddos_protection_l4_entries.yml
+++ b/examples/single_task/cgnv6/ddos_protection/a10_cgnv6_ddos_protection_l4_entries.yml
@@ -1,12 +1,7 @@
-- name: a10_cgnv6_ddos_protection_l4_entries
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_ddos_protection_l4_entries
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_ddos_protection_l4_entries
-    a10_cgnv6_ddos_protection_l4_entries:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: a10.acos_axapi.a10_cgnv6_ddos_protection_l4_entries
+    a10.acos_axapi.a10_cgnv6_ddos_protection_l4_entries:
       state: "present"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"    

--- a/examples/single_task/cgnv6/dns64/a10_cgnv6_dns64.yml
+++ b/examples/single_task/cgnv6/dns64/a10_cgnv6_dns64.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_dns64 Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_dns64 Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_dns64
-    a10_cgnv6_dns64:
-      a10_host: "{{ a10_host }}" 
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_dns64
+    a10.acos_axapi.a10_cgnv6_dns64:
       state: "present"
       partition: "MyPartition"
       get_type: "single"

--- a/examples/single_task/cgnv6/dns64/a10_cgnv6_dns64_virtualserver.yml
+++ b/examples/single_task/cgnv6/dns64/a10_cgnv6_dns64_virtualserver.yml
@@ -1,15 +1,10 @@
-- name: a10_cgnv6_dns64_virtualserver Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_dns64_virtualserver Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_dns64_virtualserver
-    a10_cgnv6_dns64_virtualserver:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: a10.acos_axapi.a10_cgnv6_dns64_virtualserver
+    a10.acos_axapi.a10_cgnv6_dns64_virtualserver:
       state: "present"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
       use_if_ip: "false"
       name: "vitualServer1"
       port_list:

--- a/examples/single_task/cgnv6/ds_lite/a10_cgnv6_ds_lite_alg_ftp.yml
+++ b/examples/single_task/cgnv6/ds_lite/a10_cgnv6_ds_lite_alg_ftp.yml
@@ -1,13 +1,8 @@
-- name: a10_cgnv6_ds_lite_alg_ftp example playbook
+- name: a10.acos_axapi.a10_cgnv6_ds_lite_alg_ftp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_ds_lite_alg_ftp
-    a10_cgnv6_ds_lite_alg_ftp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_ds_lite_alg_ftp
+    a10.acos_axapi.a10_cgnv6_ds_lite_alg_ftp:
       partition: "MyPartition"
       ftp_enable: "disable"

--- a/examples/single_task/cgnv6/ds_lite/a10_cgnv6_ds_lite_alg_h323.yml
+++ b/examples/single_task/cgnv6/ds_lite/a10_cgnv6_ds_lite_alg_h323.yml
@@ -1,13 +1,8 @@
-- name: a10_cgnv6_ds_lite_alg_h323 example playbook
+- name: a10.acos_axapi.a10_cgnv6_ds_lite_alg_h323 example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_ds_lite_alg_h323
-    a10_cgnv6_ds_lite_alg_h323:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_ds_lite_alg_h323
+    a10.acos_axapi.a10_cgnv6_ds_lite_alg_h323:
       partition: "MyPartition"
       h323_enable: "enable"

--- a/examples/single_task/cgnv6/ds_lite/a10_cgnv6_ds_lite_alg_mgcp.yml
+++ b/examples/single_task/cgnv6/ds_lite/a10_cgnv6_ds_lite_alg_mgcp.yml
@@ -1,13 +1,8 @@
-- name: a10_cgnv6_ds_lite_alg_mgcp example playbook
+- name: a10.acos_axapi.a10_cgnv6_ds_lite_alg_mgcp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_ds_lite_alg_mgcp
-    a10_cgnv6_ds_lite_alg_mgcp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_ds_lite_alg_mgcp
+    a10.acos_axapi.a10_cgnv6_ds_lite_alg_mgcp:
       partition: "MyPartition"
       mgcp_enable: "enable"

--- a/examples/single_task/cgnv6/ds_lite/a10_cgnv6_ds_lite_alg_pptp.yml
+++ b/examples/single_task/cgnv6/ds_lite/a10_cgnv6_ds_lite_alg_pptp.yml
@@ -1,13 +1,8 @@
-- name: a10_cgnv6_ds_lite_alg_pptp example playbook
+- name: a10.acos_axapi.a10_cgnv6_ds_lite_alg_pptp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_ds_lite_alg_pptp
-    a10_cgnv6_ds_lite_alg_pptp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_ds_lite_alg_pptp
+    a10.acos_axapi.a10_cgnv6_ds_lite_alg_pptp:
       partition: "MyPartition"
       pptp_enable: "enable"

--- a/examples/single_task/cgnv6/ds_lite/a10_cgnv6_ds_lite_alg_rtsp.yml
+++ b/examples/single_task/cgnv6/ds_lite/a10_cgnv6_ds_lite_alg_rtsp.yml
@@ -1,13 +1,8 @@
-- name: a10_cgnv6_ds_lite_alg_rtsp example playbook
+- name: a10.acos_axapi.a10_cgnv6_ds_lite_alg_rtsp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_ds_lite_alg_rtsp
-    a10_cgnv6_ds_lite_alg_rtsp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_ds_lite_alg_rtsp
+    a10.acos_axapi.a10_cgnv6_ds_lite_alg_rtsp:
       partition: "MyPartition"
       rtsp_enable: "enable"

--- a/examples/single_task/cgnv6/ds_lite/a10_cgnv6_ds_lite_alg_sip.yml
+++ b/examples/single_task/cgnv6/ds_lite/a10_cgnv6_ds_lite_alg_sip.yml
@@ -1,13 +1,8 @@
-- name: a10_cgnv6_ds_lite_alg_sip example playbook
+- name: a10.acos_axapi.a10_cgnv6_ds_lite_alg_sip example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_ds_lite_alg_sip
-    a10_cgnv6_ds_lite_alg_sip:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_ds_lite_alg_sip
+    a10.acos_axapi.a10_cgnv6_ds_lite_alg_sip:
       partition: "MyPartition"
       sip_enable: "enable"

--- a/examples/single_task/cgnv6/ds_lite/a10_cgnv6_ds_lite_alg_tftp.yml
+++ b/examples/single_task/cgnv6/ds_lite/a10_cgnv6_ds_lite_alg_tftp.yml
@@ -1,13 +1,8 @@
-- name: a10_cgnv6_ds_lite_alg_tftp example playbook
+- name: a10.acos_axapi.a10_cgnv6_ds_lite_alg_tftp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_ds_lite_alg_tftp
-    a10_cgnv6_ds_lite_alg_tftp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_ds_lite_alg_tftp
+    a10.acos_axapi.a10_cgnv6_ds_lite_alg_tftp:
       partition: "MyPartition"
       tftp_enable: "enable"

--- a/examples/single_task/cgnv6/ds_lite/a10_cgnv6_ds_lite_fragmentation_inbound.yml
+++ b/examples/single_task/cgnv6/ds_lite/a10_cgnv6_ds_lite_fragmentation_inbound.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_ds_lite_fragmentation_inbound example playbook
+- name: a10.acos_axapi.a10_cgnv6_ds_lite_fragmentation_inbound example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_ds_lite_fragmentation_inbound
-    a10_cgnv6_ds_lite_fragmentation_inbound:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_ds_lite_fragmentation_inbound
+    a10.acos_axapi.a10_cgnv6_ds_lite_fragmentation_inbound:
       partition: "MyPartition"
       frag_action: "drop"
       df_set: "drop"       

--- a/examples/single_task/cgnv6/ds_lite/a10_cgnv6_ds_lite_fragmentation_outbound.yml
+++ b/examples/single_task/cgnv6/ds_lite/a10_cgnv6_ds_lite_fragmentation_outbound.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_ds_lite_fragmentation_outbound example playbook
+- name: a10.acos_axapi.a10_cgnv6_ds_lite_fragmentation_outbound example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_ds_lite_fragmentation_outbound
-    a10_cgnv6_ds_lite_fragmentation_outbound:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_ds_lite_fragmentation_outbound
+    a10.acos_axapi.a10_cgnv6_ds_lite_fragmentation_outbound:
       partition: "MyPartition"
       frag_action: "drop"
       df_set: "drop"       

--- a/examples/single_task/cgnv6/ds_lite/a10_cgnv6_ds_lite_full_cone_session.yml
+++ b/examples/single_task/cgnv6/ds_lite/a10_cgnv6_ds_lite_full_cone_session.yml
@@ -1,12 +1,7 @@
-- name: a10_cgnv6_ds_lite_full_cone_session example playbook
+- name: a10.acos_axapi.a10_cgnv6_ds_lite_full_cone_session example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_ds_lite_full_cone_session
-    a10_cgnv6_ds_lite_full_cone_session:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_ds_lite_full_cone_session
+    a10.acos_axapi.a10_cgnv6_ds_lite_full_cone_session:
       partition: "MyPartition"

--- a/examples/single_task/cgnv6/ds_lite/a10_cgnv6_ds_lite_global.yml
+++ b/examples/single_task/cgnv6/ds_lite/a10_cgnv6_ds_lite_global.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_ds_lite_global example playbook
+- name: a10.acos_axapi.a10_cgnv6_ds_lite_global example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_ds_lite_global
-    a10_cgnv6_ds_lite_global:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_ds_lite_global
+    a10.acos_axapi.a10_cgnv6_ds_lite_global:
       partition: "MyPartition"
       inside:
         source: 

--- a/examples/single_task/cgnv6/ds_lite/a10_cgnv6_ds_lite_port_reservation_entries.yml
+++ b/examples/single_task/cgnv6/ds_lite/a10_cgnv6_ds_lite_port_reservation_entries.yml
@@ -1,12 +1,7 @@
-- name: a10_cgnv6_ds_lite_port_reservation_entries example playbook
+- name: a10.acos_axapi.a10_cgnv6_ds_lite_port_reservation_entries example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_ds_lite_port_reservation_entries
-    a10_cgnv6_ds_lite_port_reservation_entries:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_ds_lite_port_reservation_entries
+    a10.acos_axapi.a10_cgnv6_ds_lite_port_reservation_entries:
       partition: "MyPartition"

--- a/examples/single_task/cgnv6/ds_lite/a10_cgnv6_ds_lite_user_quota_session.yml
+++ b/examples/single_task/cgnv6/ds_lite/a10_cgnv6_ds_lite_user_quota_session.yml
@@ -1,12 +1,7 @@
-- name: a10_cgnv6_ds_lite_user_quota_session example playbook
+- name: a10.acos_axapi.a10_cgnv6_ds_lite_user_quota_session example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_ds_lite_user_quota_session
-    a10_cgnv6_ds_lite_user_quota_session:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_ds_lite_user_quota_session
+    a10.acos_axapi.a10_cgnv6_ds_lite_user_quota_session:
       partition: "MyPartition"

--- a/examples/single_task/cgnv6/fixedNat/a10_cgnv6_fixed_nat_alg_esp.yml
+++ b/examples/single_task/cgnv6/fixedNat/a10_cgnv6_fixed_nat_alg_esp.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_fixed_nat_alg_esp Example PlayBook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_fixed_nat_alg_esp Example PlayBook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_fixed_nat_alg_esp
-    a10_cgnv6_fixed_nat_alg_esp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_fixed_nat_alg_esp
+    a10.acos_axapi.a10_cgnv6_fixed_nat_alg_esp:
       partition: "MyPartition"
       sampling_enable:
         - counters1: "all"

--- a/examples/single_task/cgnv6/fixedNat/a10_cgnv6_fixed_nat_alg_ftp.yml
+++ b/examples/single_task/cgnv6/fixedNat/a10_cgnv6_fixed_nat_alg_ftp.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_fixed_nat_alg_ftp Example PlayBook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_fixed_nat_alg_ftp Example PlayBook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_fixed_nat_alg_ftp
-    a10_cgnv6_fixed_nat_alg_ftp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_fixed_nat_alg_ftp
+    a10.acos_axapi.a10_cgnv6_fixed_nat_alg_ftp:
       partition: "MyPartition"
       sampling_enable:
         - counters1: "all"

--- a/examples/single_task/cgnv6/fixedNat/a10_cgnv6_fixed_nat_alg_h323.yml
+++ b/examples/single_task/cgnv6/fixedNat/a10_cgnv6_fixed_nat_alg_h323.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_fixed_nat_alg_h323 Example PlayBook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_fixed_nat_alg_h323 Example PlayBook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_fixed_nat_alg_h323
-    a10_cgnv6_fixed_nat_alg_h323:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_fixed_nat_alg_h323
+    a10.acos_axapi.a10_cgnv6_fixed_nat_alg_h323:
       partition: "MyPartition"
       sampling_enable:
         - counters1: "all"

--- a/examples/single_task/cgnv6/fixedNat/a10_cgnv6_fixed_nat_alg_mgcp.yml
+++ b/examples/single_task/cgnv6/fixedNat/a10_cgnv6_fixed_nat_alg_mgcp.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_fixed_nat_alg_mgcp Example PlayBook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_fixed_nat_alg_mgcp Example PlayBook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_fixed_nat_alg_mgcp
-    a10_cgnv6_fixed_nat_alg_mgcp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_fixed_nat_alg_mgcp
+    a10.acos_axapi.a10_cgnv6_fixed_nat_alg_mgcp:
       partition: "MyPartition"
       sampling_enable:
         - counters1: "all"

--- a/examples/single_task/cgnv6/fixedNat/a10_cgnv6_fixed_nat_alg_pptp.yml
+++ b/examples/single_task/cgnv6/fixedNat/a10_cgnv6_fixed_nat_alg_pptp.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_fixed_nat_alg_pptp Example PlayBook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_fixed_nat_alg_pptp Example PlayBook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_fixed_nat_alg_pptp
-    a10_cgnv6_fixed_nat_alg_pptp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_fixed_nat_alg_pptp
+    a10.acos_axapi.a10_cgnv6_fixed_nat_alg_pptp:
       partition: "MyPartition"
       sampling_enable:
         - counters1: "all"

--- a/examples/single_task/cgnv6/fixedNat/a10_cgnv6_fixed_nat_alg_rtsp.yml
+++ b/examples/single_task/cgnv6/fixedNat/a10_cgnv6_fixed_nat_alg_rtsp.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_fixed_nat_alg_rtsp Example PlayBook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_fixed_nat_alg_rtsp Example PlayBook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_fixed_nat_alg_rtsp
-    a10_cgnv6_fixed_nat_alg_rtsp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_fixed_nat_alg_rtsp
+    a10.acos_axapi.a10_cgnv6_fixed_nat_alg_rtsp:
       partition: "MyPartition"
       sampling_enable:
         - counters1: "all"

--- a/examples/single_task/cgnv6/fixedNat/a10_cgnv6_fixed_nat_alg_sip.yml
+++ b/examples/single_task/cgnv6/fixedNat/a10_cgnv6_fixed_nat_alg_sip.yml
@@ -1,14 +1,9 @@
-- name:  a10_cgnv6_fixed_nat_alg_sip example playbook
+- name:  a10.acos_axapi.a10_cgnv6_fixed_nat_alg_sip example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create  a10_cgnv6_fixed_nat_alg_sip
-    a10_cgnv6_fixed_nat_alg_sip:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create  a10.acos_axapi.a10_cgnv6_fixed_nat_alg_sip
+    a10.acos_axapi.a10_cgnv6_fixed_nat_alg_sip:
       partition: "MyPartition"
       sampling_enable:
        - counters1: "all"

--- a/examples/single_task/cgnv6/fixedNat/a10_cgnv6_fixed_nat_alg_tftp.yml
+++ b/examples/single_task/cgnv6/fixedNat/a10_cgnv6_fixed_nat_alg_tftp.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_fixed_nat_alg_tftp Example PlayBook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_fixed_nat_alg_tftp Example PlayBook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_fixed_nat_alg_tftp
-    a10_cgnv6_fixed_nat_alg_tftp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_fixed_nat_alg_tftp
+    a10.acos_axapi.a10_cgnv6_fixed_nat_alg_tftp:
       partition: "MyPartition"
       sampling_enable:
         - counters1: "all"

--- a/examples/single_task/cgnv6/fixedNat/a10_cgnv6_fixed_nat_full_cone_session.yml
+++ b/examples/single_task/cgnv6/fixedNat/a10_cgnv6_fixed_nat_full_cone_session.yml
@@ -1,12 +1,7 @@
-- name: a10_cgnv6_fixed_nat_full_cone_session Example PlayBook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_fixed_nat_full_cone_session Example PlayBook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_fixed_nat_full_cone_session
-    a10_cgnv6_fixed_nat_full_cone_session:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_fixed_nat_full_cone_session
+    a10.acos_axapi.a10_cgnv6_fixed_nat_full_cone_session:
       partition: "MyPartition"

--- a/examples/single_task/cgnv6/fixedNat/a10_cgnv6_fixed_nat_global.yml
+++ b/examples/single_task/cgnv6/fixedNat/a10_cgnv6_fixed_nat_global.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_fixed_nat_global example playbook
+- name: a10.acos_axapi.a10_cgnv6_fixed_nat_global example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_fixed_nat_global
-    a10_cgnv6_fixed_nat_global:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_fixed_nat_global
+    a10.acos_axapi.a10_cgnv6_fixed_nat_global:
       create_port_mapping_file: "1"
       sampling_enable:
         - counters1: "all"

--- a/examples/single_task/cgnv6/fixedNat/a10_cgnv6_fixed_nat_inside_iplist.yml
+++ b/examples/single_task/cgnv6/fixedNat/a10_cgnv6_fixed_nat_inside_iplist.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_fixed_nat_inside_iplist Example Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_fixed_nat_inside_iplist Example Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_fixed_nat_inside_iplist
-    a10_cgnv6_fixed_nat_inside_iplist:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_fixed_nat_inside_iplist
+    a10.acos_axapi.a10_cgnv6_fixed_nat_inside_iplist:
       state: "present"
       vrid: 1
       ports_per_user: 1

--- a/examples/single_task/cgnv6/fixedNat/a10_cgnv6_fixed_nat_inside_ipv4address.yml
+++ b/examples/single_task/cgnv6/fixedNat/a10_cgnv6_fixed_nat_inside_ipv4address.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_fixed_nat_inside_ipv4address
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_fixed_nat_inside_ipv4address
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_fixed_nat_inside_ipv4address
-    a10_cgnv6_fixed_nat_inside_ipv4address:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_fixed_nat_inside_ipv4address
+    a10.acos_axapi.a10_cgnv6_fixed_nat_inside_ipv4address:
       state: "present"
       inside_netmask: "255.0.0.0"
       nat_end_address: "10.10.1.32"

--- a/examples/single_task/cgnv6/fixedNat/a10_cgnv6_fixed_nat_port_mapping.yml
+++ b/examples/single_task/cgnv6/fixedNat/a10_cgnv6_fixed_nat_port_mapping.yml
@@ -1,12 +1,7 @@
-- name: a10_cgnv6_fixed_nat_port_mapping Example PlayBook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_fixed_nat_port_mapping Example PlayBook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_fixed_nat_port_mapping
-    a10_cgnv6_fixed_nat_port_mapping:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_fixed_nat_port_mapping
+    a10.acos_axapi.a10_cgnv6_fixed_nat_port_mapping:
       partition: "MyPartition"

--- a/examples/single_task/cgnv6/fixedNat/a10_cgnv6_fixed_nat_user_quota.yml
+++ b/examples/single_task/cgnv6/fixedNat/a10_cgnv6_fixed_nat_user_quota.yml
@@ -1,12 +1,7 @@
-- name: a10_cgnv6_fixed_nat_user_quota Example Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_fixed_nat_user_quota Example Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_fixed_nat_user_quota
-    a10_cgnv6_fixed_nat_user_quota:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_fixed_nat_user_quota
+    a10.acos_axapi.a10_cgnv6_fixed_nat_user_quota:
       state: "present"

--- a/examples/single_task/cgnv6/logging/a10_cgnv6_logging.yml
+++ b/examples/single_task/cgnv6/logging/a10_cgnv6_logging.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_logging Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_logging Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_logging
-    a10_cgnv6_logging:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_logging
+    a10.acos_axapi.a10_cgnv6_logging:
       state: "present"
       nat_quota_exceeded:
         level: "warning"

--- a/examples/single_task/cgnv6/logging/a10_cgnv6_logging_nat_quota_exceeded.yml
+++ b/examples/single_task/cgnv6/logging/a10_cgnv6_logging_nat_quota_exceeded.yml
@@ -1,13 +1,8 @@
-- name: a10_cgnv6_logging_nat_quota_exceeded
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_logging_nat_quota_exceeded
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_logging_nat_quota_exceeded
-    a10_cgnv6_logging_nat_quota_exceeded:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_logging_nat_quota_exceeded
+    a10.acos_axapi.a10_cgnv6_logging_nat_quota_exceeded:
       state: "present"
       level: "warning"

--- a/examples/single_task/cgnv6/logging/a10_cgnv6_logging_nat_resource_exhausted.yml
+++ b/examples/single_task/cgnv6/logging/a10_cgnv6_logging_nat_resource_exhausted.yml
@@ -1,13 +1,8 @@
-- name: a10_cgnv6_logging_nat_resource_exhausted
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_logging_nat_resource_exhausted
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_logging_nat_resource_exhausted
-    a10_cgnv6_logging_nat_resource_exhausted:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_logging_nat_resource_exhausted
+    a10.acos_axapi.a10_cgnv6_logging_nat_resource_exhausted:
       state: "present"
       level: "warning"

--- a/examples/single_task/cgnv6/logging/a10_cgnv6_logging_source_address.yml
+++ b/examples/single_task/cgnv6/logging/a10_cgnv6_logging_source_address.yml
@@ -1,12 +1,7 @@
-- name: a10_cgnv6_logging_source_address Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_logging_source_address Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_logging_source_address
-    a10_cgnv6_logging_source_address:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: a10.acos_axapi.a10_cgnv6_logging_source_address
+    a10.acos_axapi.a10_cgnv6_logging_source_address:
       state: "present"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"

--- a/examples/single_task/cgnv6/logging/a10_cgnv6_logging_tcp_svr_status.yml
+++ b/examples/single_task/cgnv6/logging/a10_cgnv6_logging_tcp_svr_status.yml
@@ -1,12 +1,7 @@
-- name: a10_cgnv6_logging_tcp_svr_status Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_logging_tcp_svr_status Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: localhost
   tasks:
-  - name: a10_cgnv6_logging_tcp_svr_status
-    a10_cgnv6_logging_tcp_svr_status:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: a10.acos_axapi.a10_cgnv6_logging_tcp_svr_status
+    a10.acos_axapi.a10_cgnv6_logging_tcp_svr_status:
       state: "present"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"

--- a/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_alg_esp.yml
+++ b/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_alg_esp.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_lsn_alg_esp Example PlayBook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_lsn_alg_esp Example PlayBook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_lsn_alg_esp
-    a10_cgnv6_lsn_alg_esp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_lsn_alg_esp
+    a10.acos_axapi.a10_cgnv6_lsn_alg_esp:
       partition: "MyPartition"
       sampling_enable:
         - counters1: "all"

--- a/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_alg_ftp.yml
+++ b/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_alg_ftp.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_lsn_alg_ftp Example PlayBook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_lsn_alg_ftp Example PlayBook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_lsn_alg_ftp
-    a10_cgnv6_lsn_alg_ftp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_lsn_alg_ftp
+    a10.acos_axapi.a10_cgnv6_lsn_alg_ftp:
       partition: "MyPartition"
       sampling_enable:
         - counters1: "all"

--- a/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_alg_h323.yml
+++ b/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_alg_h323.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_lsn_alg_h323 Example PlayBook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_lsn_alg_h323 Example PlayBook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_lsn_alg_h323
-    a10_cgnv6_lsn_alg_h323:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_lsn_alg_h323
+    a10.acos_axapi.a10_cgnv6_lsn_alg_h323:
       partition: "MyPartition"
       h323_value: "enable"
       sampling_enable: 

--- a/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_alg_mgcp.yml
+++ b/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_alg_mgcp.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_lsn_alg_mgcp Example PlayBook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_lsn_alg_mgcp Example PlayBook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_lsn_alg_mgcp
-    a10_cgnv6_lsn_alg_mgcp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_lsn_alg_mgcp
+    a10.acos_axapi.a10_cgnv6_lsn_alg_mgcp:
       partition: "MyPartition"
       mgcp_value: "enable"
       sampling_enable: 

--- a/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_alg_pptp.yml
+++ b/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_alg_pptp.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_lsn_alg_pptp Example PlayBook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_lsn_alg_pptp Example PlayBook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_lsn_alg_pptp
-    a10_cgnv6_lsn_alg_pptp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_lsn_alg_pptp
+    a10.acos_axapi.a10_cgnv6_lsn_alg_pptp:
       partition: "MyPartition"
       pptp_value: "enable"
       sampling_enable: 

--- a/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_alg_rtp.yml
+++ b/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_alg_rtp.yml
@@ -1,13 +1,8 @@
-- name: a10_cgnv6_lsn_alg_rtp Example PlayBook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_lsn_alg_rtp Example PlayBook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_lsn_alg_rtp
-    a10_cgnv6_lsn_alg_rtp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_lsn_alg_rtp
+    a10.acos_axapi.a10_cgnv6_lsn_alg_rtp:
       partition: "MyPartition"
       rtp_stun_timeout: "10"

--- a/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_alg_rtsp.yml
+++ b/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_alg_rtsp.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_lsn_alg_h323 Example PlayBook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_lsn_alg_h323 Example PlayBook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_lsn_alg_h323
-    a10_cgnv6_lsn_alg_h323:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_lsn_alg_h323
+    a10.acos_axapi.a10_cgnv6_lsn_alg_h323:
       partition: "MyPartition"
       h323_value: "enable"
       sampling_enable: 

--- a/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_alg_sip.yml
+++ b/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_alg_sip.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_lsn_alg_sip Example PlayBook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_lsn_alg_sip Example PlayBook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_lsn_alg_sip
-    a10_cgnv6_lsn_alg_sip:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_lsn_alg_sip
+    a10.acos_axapi.a10_cgnv6_lsn_alg_sip:
       partition: "MyPartition"
       sampling_enable:
         - counters1: "all"

--- a/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_alg_tftp.yml
+++ b/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_alg_tftp.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_lsn_alg_tftp Example PlayBook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_lsn_alg_tftp Example PlayBook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_lsn_alg_tftp
-    a10_cgnv6_lsn_alg_tftp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_lsn_alg_tftp
+    a10.acos_axapi.a10_cgnv6_lsn_alg_tftp:
       partition: "MyPartition"
       tftp_value: "enable"
       sampling_enable: 

--- a/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_all_sessions.yml
+++ b/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_all_sessions.yml
@@ -1,11 +1,6 @@
-- name: a10_cgnv6_lsn_all_sessions example playbook
+- name: a10.acos_axapi.a10_cgnv6_lsn_all_sessions example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: a10_cgnv6_lsn_all_sessions
-    a10_cgnv6_lsn_all_sessions:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_lsn_all_sessions
+    a10.acos_axapi.a10_cgnv6_lsn_all_sessions:

--- a/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_endpoint_independent_filtering_tcp.yml
+++ b/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_endpoint_independent_filtering_tcp.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_lsn_endpoint_independent_filtering_tcp Example PlayBook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_lsn_endpoint_independent_filtering_tcp Example PlayBook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_lsn_endpoint_independent_filtering_tcp
-    a10_cgnv6_lsn_endpoint_independent_filtering_tcp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_lsn_endpoint_independent_filtering_tcp
+    a10.acos_axapi.a10_cgnv6_lsn_endpoint_independent_filtering_tcp:
       partition: "MyPartition"
       port_list:
        - port: "8080"

--- a/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_endpoint_independent_filtering_udp.yml
+++ b/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_endpoint_independent_filtering_udp.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_lsn_endpoint_independent_filtering_udp Example PlayBook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_lsn_endpoint_independent_filtering_udp Example PlayBook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_lsn_endpoint_independent_filtering_udp
-    a10_cgnv6_lsn_endpoint_independent_filtering_udp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_lsn_endpoint_independent_filtering_udp
+    a10.acos_axapi.a10_cgnv6_lsn_endpoint_independent_filtering_udp:
       partition: "MyPartition"
       port_list:
        - port: "8080"

--- a/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_endpoint_independent_mapping_tcp.yml
+++ b/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_endpoint_independent_mapping_tcp.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_lsn_endpoint_independent_mapping_tcp Example PlayBook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_lsn_endpoint_independent_mapping_tcp Example PlayBook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_lsn_endpoint_independent_mapping_tcp
-    a10_cgnv6_lsn_endpoint_independent_mapping_tcp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_lsn_endpoint_independent_mapping_tcp
+    a10.acos_axapi.a10_cgnv6_lsn_endpoint_independent_mapping_tcp:
       partition: "MyPartition"
       port_list:
        - port: "8080"

--- a/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_endpoint_independent_mapping_udp.yml
+++ b/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_endpoint_independent_mapping_udp.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_lsn_endpoint_independent_mapping_udp Example PlayBook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_lsn_endpoint_independent_mapping_udp Example PlayBook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_lsn_endpoint_independent_mapping_udp
-    a10_cgnv6_lsn_endpoint_independent_mapping_udp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_lsn_endpoint_independent_mapping_udp
+    a10.acos_axapi.a10_cgnv6_lsn_endpoint_independent_mapping_udp:
       partition: "MyPartition"
       port_list:
        - port: "8080"

--- a/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_enhanced_user_tracking.yml
+++ b/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_enhanced_user_tracking.yml
@@ -1,12 +1,7 @@
-- name: a10_cgnv6_lsn_enhanced_user_tracking Example Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_lsn_enhanced_user_tracking Example Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_lsn_enhanced_user_tracking
-    a10_cgnv6_lsn_enhanced_user_tracking:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
+  - name: a10.acos_axapi.a10_cgnv6_lsn_enhanced_user_tracking
+    a10.acos_axapi.a10_cgnv6_lsn_enhanced_user_tracking:
       state: "present"
-      a10_protocol: "{{ a10_protocol }}"

--- a/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_full_cone_session.yml
+++ b/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_full_cone_session.yml
@@ -1,12 +1,7 @@
-- name: a10_cgnv6_lsn_full_cone_session Example Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_lsn_full_cone_session Example Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_lsn_full_cone_session
-    a10_cgnv6_lsn_full_cone_session:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
+  - name: a10.acos_axapi.a10_cgnv6_lsn_full_cone_session
+    a10.acos_axapi.a10_cgnv6_lsn_full_cone_session:
       state: "present"
-      a10_protocol: "{{ a10_protocol }}"

--- a/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_global.yml
+++ b/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_global.yml
@@ -1,15 +1,10 @@
-- name: a10_cgnv6_lsn_global Example Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_lsn_global Example Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_lsn_global
-    a10_cgnv6_lsn_global:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
+  - name: a10.acos_axapi.a10_cgnv6_lsn_global
+    a10.acos_axapi.a10_cgnv6_lsn_global:
       state: "present"
-      a10_protocol: "{{ a10_protocol }}"
       strictly_sticky_nat: "false"
       logging:
         default_template: "LsnTemplate1"

--- a/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_health_check_gateway.yml
+++ b/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_health_check_gateway.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_lsn_health_check_gateway Example Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_lsn_health_check_gateway Example Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_lsn_health_check_gateway
-    a10_cgnv6_lsn_health_check_gateway:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
+  - name: a10.acos_axapi.a10_cgnv6_lsn_health_check_gateway
+    a10.acos_axapi.a10_cgnv6_lsn_health_check_gateway:
       state: "present"
-      a10_protocol: "{{ a10_protocol }}"
       ipv4_addr: "192.168.1.26"
       ipv6_addr: "2001:0db8:85a3:0000:0000:8a2e:0370:7334"  

--- a/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_inside_source.yml
+++ b/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_inside_source.yml
@@ -1,13 +1,8 @@
-- name: a10_cgnv6_lsn_inside_source Example PlayBook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_lsn_inside_source Example PlayBook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_lsn_inside_source
-    a10_cgnv6_lsn_inside_source:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_lsn_inside_source
+    a10.acos_axapi.a10_cgnv6_lsn_inside_source:
       partition: "MyPartition"
       class_list: "TestClassList"

--- a/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_lid.yml
+++ b/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_lid.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_lsn_lid Example PlayBook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_lsn_lid Example PlayBook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_lsn_lid
-    a10_cgnv6_lsn_lid:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_lsn_lid
+    a10.acos_axapi.a10_cgnv6_lsn_lid:
       partition: "MyPartition"
       user_quota_prefix_length:
       extended_user_quota:

--- a/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_performance.yml
+++ b/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_performance.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_lsn_performance Example PlayBook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_lsn_performance Example PlayBook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_lsn_performance
-    a10_cgnv6_lsn_performance:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_lsn_performance
+    a10.acos_axapi.a10_cgnv6_lsn_performance:
       partition: "MyPartition"
       sampling_enable: 
         - counters1: "all"

--- a/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_port_reservation_entries.yml
+++ b/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_port_reservation_entries.yml
@@ -1,12 +1,7 @@
-- name: a10_cgnv6_lsn_port_reservation_entries Example PlayBook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_lsn_port_reservation_entries Example PlayBook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_lsn_port_reservation_entries
-    a10_cgnv6_lsn_port_reservation_entries:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_lsn_port_reservation_entries
+    a10.acos_axapi.a10_cgnv6_lsn_port_reservation_entries:
       partition: "MyPartition"

--- a/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_radius_profile.yml
+++ b/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_radius_profile.yml
@@ -1,15 +1,10 @@
-- name: a10_cgnv6_lsn_radius_profile Example Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_lsn_radius_profile Example Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_lsn_radius_profile
-    a10_cgnv6_lsn_radius_profile:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
+  - name: a10.acos_axapi.a10_cgnv6_lsn_radius_profile
+    a10.acos_axapi.a10_cgnv6_lsn_radius_profile:
       state: "present"
-      a10_protocol: "{{ a10_protocol }}"
       lid_profile_index: 9 
       radius: 
         - attribute: "custom1"

--- a/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_radius_server.yml
+++ b/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_radius_server.yml
@@ -1,15 +1,10 @@
-- name: a10_cgnv6_lsn_radius_server Example Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_lsn_radius_server Example Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_lsn_radius_server
-    a10_cgnv6_lsn_radius_server:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
+  - name: a10.acos_axapi.a10_cgnv6_lsn_radius_server
+    a10.acos_axapi.a10_cgnv6_lsn_radius_server:
       state: "present"
-      a10_protocol: "{{ a10_protocol }}"
       accounting_start: "append-entry"
       disable_reply: "false"
       accounting_interim_update: "ignore"

--- a/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_rule_list_domain_ip.yml
+++ b/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_rule_list_domain_ip.yml
@@ -1,15 +1,10 @@
-- name: a10_cgnv6_lsn_rule_list_domain_ip Example Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_lsn_rule_list_domain_ip Example Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_lsn_rule_list_domain_ip
-    a10_cgnv6_lsn_rule_list_domain_ip:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
+  - name: a10.acos_axapi.a10_cgnv6_lsn_rule_list_domain_ip
+    a10.acos_axapi.a10_cgnv6_lsn_rule_list_domain_ip:
       state: "present"
-      a10_protocol: "{{ a10_protocol }}"
       sampling_enable:
         - counters1: "all"
       lsn_rule_list_name: "RuleList1"      

--- a/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_rule_list_domain_name.yml
+++ b/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_rule_list_domain_name.yml
@@ -1,15 +1,10 @@
-- name: a10_cgnv6_lsn_rule_list_domain_name Example Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_lsn_rule_list_domain_name Example Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_lsn_rule_list_domain_name
-    a10_cgnv6_lsn_rule_list_domain_name:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
+  - name: a10.acos_axapi.a10_cgnv6_lsn_rule_list_domain_name
+    a10.acos_axapi.a10_cgnv6_lsn_rule_list_domain_name:
       state: "present"
-      a10_protocol: "{{ a10_protocol }}"
       name_domain: "TestDomain"
       sampling_enable:
         - counters1: "all"

--- a/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_rule_list_ip.yml
+++ b/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_rule_list_ip.yml
@@ -1,15 +1,10 @@
-- name: a10_cgnv6_lsn_rule_list_ip Example Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_lsn_rule_list_ip Example Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_pcp
-    a10_cgnv6_pcp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
+  - name: a10.acos_axapi.a10_cgnv6_pcp
+    a10.acos_axapi.a10_cgnv6_pcp:
       state: "present"
-      a10_protocol: "{{ a10_protocol }}"
       sampling_enable:
         - counters1: "all"
       default_template: "LsnTemplate1"

--- a/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_stun_timeout_tcp.yml
+++ b/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_stun_timeout_tcp.yml
@@ -1,15 +1,10 @@
-- name: a10_cgnv6_lsn_stun_timeout_tcp Example Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_lsn_stun_timeout_tcp Example Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_lsn_stun_timeout_tcp
-    a10_cgnv6_lsn_stun_timeout_tcp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
+  - name: a10.acos_axapi.a10_cgnv6_lsn_stun_timeout_tcp
+    a10.acos_axapi.a10_cgnv6_lsn_stun_timeout_tcp:
       state: "present"
-      a10_protocol: "{{ a10_protocol }}"
       port_start: 8080
       port_end: 8090
       timeout: 4

--- a/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_stun_timeout_udp.yml
+++ b/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_stun_timeout_udp.yml
@@ -1,15 +1,10 @@
-- name: a10_cgnv6_lsn_stun_timeout_udp Example Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_lsn_stun_timeout_udp Example Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_lsn_stun_timeout_udp
-    a10_cgnv6_lsn_stun_timeout_udp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
+  - name: a10.acos_axapi.a10_cgnv6_lsn_stun_timeout_udp
+    a10.acos_axapi.a10_cgnv6_lsn_stun_timeout_udp:
       state: "present"
-      a10_protocol: "{{ a10_protocol }}"
       port_start: 8085
       port_end: 8095
       timeout: 4

--- a/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_system_status.yml
+++ b/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_system_status.yml
@@ -1,12 +1,7 @@
-- name: a10_cgnv6_lsn_system_status Example PlayBook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_lsn_system_status Example PlayBook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_lsn_system_status
-    a10_cgnv6_lsn_system_status:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_lsn_system_status
+    a10.acos_axapi.a10_cgnv6_lsn_system_status:
       partition: "MyPartition"

--- a/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_user_quota_session.yml
+++ b/examples/single_task/cgnv6/lsn/a10_cgnv6_lsn_user_quota_session.yml
@@ -1,12 +1,7 @@
-- name: a10_cgnv6_lsn_user_quota_session Example Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_lsn_user_quota_session Example Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_lsn_user_quota_session
-    a10_cgnv6_lsn_user_quota_session:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
+  - name: a10.acos_axapi.a10_cgnv6_lsn_user_quota_session
+    a10.acos_axapi.a10_cgnv6_lsn_user_quota_session:
       state: "present"
-      a10_protocol: "{{ a10_protocol }}"

--- a/examples/single_task/cgnv6/lw_4o6/a10_cgnv6_lw_4o6_active_binding_table.yml
+++ b/examples/single_task/cgnv6/lw_4o6/a10_cgnv6_lw_4o6_active_binding_table.yml
@@ -1,11 +1,6 @@
-- name: a10_cgnv6_lw_4o6_active_binding_table example playbook
+- name: a10.acos_axapi.a10_cgnv6_lw_4o6_active_binding_table example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: a10_cgnv6_lw_4o6_active_binding_table
-    a10_cgnv6_lw_4o6_active_binding_table:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_lw_4o6_active_binding_table
+    a10.acos_axapi.a10_cgnv6_lw_4o6_active_binding_table:

--- a/examples/single_task/cgnv6/lw_4o6/a10_cgnv6_lw_4o6_all_binding_tables.yml
+++ b/examples/single_task/cgnv6/lw_4o6/a10_cgnv6_lw_4o6_all_binding_tables.yml
@@ -1,11 +1,6 @@
-- name: a10_cgnv6_lw_4o6_all_binding_tables example playbook
+- name: a10.acos_axapi.a10_cgnv6_lw_4o6_all_binding_tables example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: a10_cgnv6_lw_4o6_all_binding_tables
-    a10_cgnv6_lw_4o6_all_binding_tables:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_lw_4o6_all_binding_tables
+    a10.acos_axapi.a10_cgnv6_lw_4o6_all_binding_tables:

--- a/examples/single_task/cgnv6/lw_4o6/a10_cgnv6_lw_4o6_binding_table.yml
+++ b/examples/single_task/cgnv6/lw_4o6/a10_cgnv6_lw_4o6_binding_table.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_lw_4o6_binding_table example playbook
+- name: a10.acos_axapi.a10_cgnv6_lw_4o6_binding_table example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: a10_cgnv6_lw_4o6_binding_table
-    a10_cgnv6_lw_4o6_binding_table:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_lw_4o6_binding_table
+    a10.acos_axapi.a10_cgnv6_lw_4o6_binding_table:
       tunnel_address_list:
         - ipv6_tunnel_addr: "2001:0db8:85a3:0000:0000:8a2e:0370:7348"
           nat_address_list:

--- a/examples/single_task/cgnv6/lw_4o6/a10_cgnv6_lw_4o6_binding_table_files_status.yml
+++ b/examples/single_task/cgnv6/lw_4o6/a10_cgnv6_lw_4o6_binding_table_files_status.yml
@@ -1,11 +1,6 @@
-- name: a10_cgnv6_lw_4o6_binding_table_files_status example playbook
+- name: a10.acos_axapi.a10_cgnv6_lw_4o6_binding_table_files_status example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: a10_cgnv6_lw_4o6_binding_table_files_status
-    a10_cgnv6_lw_4o6_binding_table_files_status:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_lw_4o6_binding_table_files_status
+    a10.acos_axapi.a10_cgnv6_lw_4o6_binding_table_files_status:

--- a/examples/single_task/cgnv6/lw_4o6/a10_cgnv6_lw_4o6_binding_table_tunnel_address.yml
+++ b/examples/single_task/cgnv6/lw_4o6/a10_cgnv6_lw_4o6_binding_table_tunnel_address.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_lw_4o6_binding_table_tunnel_address example playbook
+- name: a10.acos_axapi.a10_cgnv6_lw_4o6_binding_table_tunnel_address example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: a10_cgnv6_lw_4o6_binding_table_tunnel_address
-    a10_cgnv6_lw_4o6_binding_table_tunnel_address:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_lw_4o6_binding_table_tunnel_address
+    a10.acos_axapi.a10_cgnv6_lw_4o6_binding_table_tunnel_address:
       ipv6_tunnel_addr: "2001:0db8:85a3:0000:0000:8a2e:0370:7337"
       binding_table_name: "TestLWBindingTable"
       nat_address_list:

--- a/examples/single_task/cgnv6/lw_4o6/a10_cgnv6_lw_4o6_binding_table_tunnel_address_nat_address.yml
+++ b/examples/single_task/cgnv6/lw_4o6/a10_cgnv6_lw_4o6_binding_table_tunnel_address_nat_address.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_lw_4o6_binding_table_tunnel_address_nat_address example playbook
+- name: a10.acos_axapi.a10_cgnv6_lw_4o6_binding_table_tunnel_address_nat_address example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: a10_cgnv6_lw_4o6_binding_table_tunnel_address_nat_address
-    a10_cgnv6_lw_4o6_binding_table_tunnel_address_nat_address:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_lw_4o6_binding_table_tunnel_address_nat_address
+    a10.acos_axapi.a10_cgnv6_lw_4o6_binding_table_tunnel_address_nat_address:
       ipv4_nat_addr: "10.10.10.6"
       tunnel_address_ipv6_tunnel_addr: "2001:0db8:85a3:0000:0000:8a2e:0370:7335"
       binding_table_name: "TestLWBindingTable"

--- a/examples/single_task/cgnv6/lw_4o6/a10_cgnv6_lw_4o6_binding_table_tunnel_address_nat_address_port_range.yml
+++ b/examples/single_task/cgnv6/lw_4o6/a10_cgnv6_lw_4o6_binding_table_tunnel_address_nat_address_port_range.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_lw_4o6_binding_table_tunnel_address_nat_address_port_range example playbook
+- name: a10.acos_axapi.a10_cgnv6_lw_4o6_binding_table_tunnel_address_nat_address_port_range example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: a10_cgnv6_lw_4o6_binding_table_tunnel_address_nat_address_port_range
-    a10_cgnv6_lw_4o6_binding_table_tunnel_address_nat_address_port_range:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_lw_4o6_binding_table_tunnel_address_nat_address_port_range
+    a10.acos_axapi.a10_cgnv6_lw_4o6_binding_table_tunnel_address_nat_address_port_range:
       nat_address_ipv4_nat_addr: "10.10.10.6"
       tunnel_address_ipv6_tunnel_addr: "2001:0db8:85a3:0000:0000:8a2e:0370:7335"
       binding_table_name: "TestLWBindingTable2"

--- a/examples/single_task/cgnv6/lw_4o6/a10_cgnv6_lw_4o6_binding_table_validate.yml
+++ b/examples/single_task/cgnv6/lw_4o6/a10_cgnv6_lw_4o6_binding_table_validate.yml
@@ -1,13 +1,8 @@
-- name: a10_cgnv6_lw_4o6_binding_table_validate Example Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_lw_4o6_binding_table_validate Example Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_lw_4o6_binding_table_validate
-    a10_cgnv6_lw_4o6_binding_table_validate:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
+  - name: a10.acos_axapi.a10_cgnv6_lw_4o6_binding_table_validate
+    a10.acos_axapi.a10_cgnv6_lw_4o6_binding_table_validate:
       state: "present"
-      a10_protocol: "{{ a10_protocol }}"
       binding_name: "bindTest"

--- a/examples/single_task/cgnv6/lw_4o6/a10_cgnv6_lw_4o6_fragmentation_inbound.yml
+++ b/examples/single_task/cgnv6/lw_4o6/a10_cgnv6_lw_4o6_fragmentation_inbound.yml
@@ -1,13 +1,8 @@
-- name: a10_cgnv6_lw_4o6_fragmentation_inbound example playbook
+- name: a10.acos_axapi.a10_cgnv6_lw_4o6_fragmentation_inbound example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: a10_cgnv6_lw_4o6_fragmentation_inbound
-    a10_cgnv6_lw_4o6_fragmentation_inbound:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_lw_4o6_fragmentation_inbound
+    a10.acos_axapi.a10_cgnv6_lw_4o6_fragmentation_inbound:
       frag_action: "ipv4"
       df_set: "ipv4"

--- a/examples/single_task/cgnv6/lw_4o6/a10_cgnv6_lw_4o6_fragmentation_outbound.yml
+++ b/examples/single_task/cgnv6/lw_4o6/a10_cgnv6_lw_4o6_fragmentation_outbound.yml
@@ -1,13 +1,8 @@
-- name: a10_cgnv6_lw_4o6_fragmentation_outbound example playbook
+- name: a10.acos_axapi.a10_cgnv6_lw_4o6_fragmentation_outbound example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: a10_cgnv6_lw_4o6_fragmentation_outbound
-    a10_cgnv6_lw_4o6_fragmentation_outbound:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_lw_4o6_fragmentation_outbound
+    a10.acos_axapi.a10_cgnv6_lw_4o6_fragmentation_outbound:
       frag_action: "drop"
       df_set: "drop"

--- a/examples/single_task/cgnv6/lw_4o6/a10_cgnv6_lw_4o6_global.yml
+++ b/examples/single_task/cgnv6/lw_4o6/a10_cgnv6_lw_4o6_global.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_lw_4o6_global example playbook
+- name: a10.acos_axapi.a10_cgnv6_lw_4o6_global example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: a10_cgnv6_lw_4o6_global
-    a10_cgnv6_lw_4o6_global:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_lw_4o6_global
+    a10.acos_axapi.a10_cgnv6_lw_4o6_global:
       no_forward_match:
         send_icmpv6: "true"
       nat_prefix_list: "TestClassList"

--- a/examples/single_task/cgnv6/lw_4o6/a10_cgnv6_lw_4o6_health_check_gateway.yml
+++ b/examples/single_task/cgnv6/lw_4o6/a10_cgnv6_lw_4o6_health_check_gateway.yml
@@ -1,13 +1,8 @@
-- name: a10_cgnv6_lw_4o6_health_check_gateway example playbook
+- name: a10.acos_axapi.a10_cgnv6_lw_4o6_health_check_gateway example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: a10_cgnv6_lw_4o6_health_check_gateway
-    a10_cgnv6_lw_4o6_health_check_gateway:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_lw_4o6_health_check_gateway
+    a10.acos_axapi.a10_cgnv6_lw_4o6_health_check_gateway:
       ipv4_addr: "10.10.10.12"
       ipv6_addr: "2001:0db8:85a3:0000:0000:8a2e:0370:7334"

--- a/examples/single_task/cgnv6/lw_4o6/a10_cgnv6_lw_4o6_validation_log_files.yml
+++ b/examples/single_task/cgnv6/lw_4o6/a10_cgnv6_lw_4o6_validation_log_files.yml
@@ -1,11 +1,6 @@
-- name: a10_cgnv6_lw_4o6_validation_log_files example playbook
+- name: a10.acos_axapi.a10_cgnv6_lw_4o6_validation_log_files example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: a10_cgnv6_lw_4o6_validation_log_files
-    a10_cgnv6_lw_4o6_validation_log_files:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_lw_4o6_validation_log_files
+    a10.acos_axapi.a10_cgnv6_lw_4o6_validation_log_files:

--- a/examples/single_task/cgnv6/map/a10_cgnv6_map_translation_domain.yml
+++ b/examples/single_task/cgnv6/map/a10_cgnv6_map_translation_domain.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_map_translation_domain example playbook
+- name: a10.acos_axapi.a10_cgnv6_map_translation_domain example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: a10_cgnv6_map_translation_domain
-    a10_cgnv6_map_translation_domain:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_map_translation_domain
+    a10.acos_axapi.a10_cgnv6_map_translation_domain:
       default_mapping_rule:
         rule_ipv6_prefix: "2001:0DB8:0000:000b:0000:0000:0000:0001/64"
       name: "TestDomain"

--- a/examples/single_task/cgnv6/map/a10_cgnv6_map_translation_domain_health_check_gateway.yml
+++ b/examples/single_task/cgnv6/map/a10_cgnv6_map_translation_domain_health_check_gateway.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_map_translation_domain_health_check_gateway example playbook
+- name: a10.acos_axapi.a10_cgnv6_map_translation_domain_health_check_gateway example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: a10_cgnv6_map_translation_domain_health_check_gateway
-    a10_cgnv6_map_translation_domain_health_check_gateway:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_map_translation_domain_health_check_gateway
+    a10.acos_axapi.a10_cgnv6_map_translation_domain_health_check_gateway:
       ipv6_address_list:
         - ipv6_gateway: "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
       address_list:

--- a/examples/single_task/cgnv6/map/a10_cgnv6_map_translation_fragmentation_inbound.yml
+++ b/examples/single_task/cgnv6/map/a10_cgnv6_map_translation_fragmentation_inbound.yml
@@ -1,13 +1,8 @@
-- name: a10_cgnv6_map_translation_fragmentation_inbound example playbook
+- name: a10.acos_axapi.a10_cgnv6_map_translation_fragmentation_inbound example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: a10_cgnv6_map_translation_fragmentation_inbound
-    a10_cgnv6_map_translation_fragmentation_inbound:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_map_translation_fragmentation_inbound
+    a10.acos_axapi.a10_cgnv6_map_translation_fragmentation_inbound:
       frag_action: "drop"
       df_set: "drop"

--- a/examples/single_task/cgnv6/map/a10_cgnv6_map_translation_fragmentation_outbound.yml
+++ b/examples/single_task/cgnv6/map/a10_cgnv6_map_translation_fragmentation_outbound.yml
@@ -1,12 +1,7 @@
-- name: a10_cgnv6_map_translation_fragmentation_outbound example playbook
+- name: a10.acos_axapi.a10_cgnv6_map_translation_fragmentation_outbound example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: a10_cgnv6_map_translation_fragmentation_outbound
-    a10_cgnv6_map_translation_fragmentation_outbound:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_map_translation_fragmentation_outbound
+    a10.acos_axapi.a10_cgnv6_map_translation_fragmentation_outbound:
       frag_action: "drop"

--- a/examples/single_task/cgnv6/map_encapsulation/a10_cgnv6_map_encapsulation_domain.yml
+++ b/examples/single_task/cgnv6/map_encapsulation/a10_cgnv6_map_encapsulation_domain.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_map_encapsulation_domain Example Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_map_encapsulation_domain Example Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_map_encapsulation_domain
-    a10_cgnv6_map_encapsulation_domain:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_map_encapsulation_domain
+    a10.acos_axapi.a10_cgnv6_map_encapsulation_domain:
       state: "present"
       description: "MapDomainDesc"
       format: "draft-03"

--- a/examples/single_task/cgnv6/map_encapsulation/a10_cgnv6_map_encapsulation_domain_basic_mapping_rule.yml
+++ b/examples/single_task/cgnv6/map_encapsulation/a10_cgnv6_map_encapsulation_domain_basic_mapping_rule.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_map_encapsulation_domain_basic_mapping_rule Example Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_map_encapsulation_domain_basic_mapping_rule Example Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_map_encapsulation_domain_basic_mapping_rule
-    a10_cgnv6_map_encapsulation_domain_basic_mapping_rule:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_map_encapsulation_domain_basic_mapping_rule
+    a10.acos_axapi.a10_cgnv6_map_encapsulation_domain_basic_mapping_rule:
       state: "present"
       rule_ipv4_address_port_settings: "prefix-addr"
       prefix_rule_list:

--- a/examples/single_task/cgnv6/map_encapsulation/a10_cgnv6_map_encapsulation_domain_basic_mapping_rule_prefix_rule.yml
+++ b/examples/single_task/cgnv6/map_encapsulation/a10_cgnv6_map_encapsulation_domain_basic_mapping_rule_prefix_rule.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_map_encapsulation_domain_basic_mapping_rule_prefix_rule Example Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_map_encapsulation_domain_basic_mapping_rule_prefix_rule Example Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_map_encapsulation_domain_basic_mapping_rule_prefix_rule
-    a10_cgnv6_map_encapsulation_domain_basic_mapping_rule_prefix_rule:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_map_encapsulation_domain_basic_mapping_rule_prefix_rule
+    a10.acos_axapi.a10_cgnv6_map_encapsulation_domain_basic_mapping_rule_prefix_rule:
       state: "present"
       name: "RuleList1"
       ipv4_address_port_settings: "prefix-addr"

--- a/examples/single_task/cgnv6/map_encapsulation/a10_cgnv6_map_encapsulation_domain_health_check_gateway.yml
+++ b/examples/single_task/cgnv6/map_encapsulation/a10_cgnv6_map_encapsulation_domain_health_check_gateway.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_map_encapsulation_domain_health_check_gateway Example Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_map_encapsulation_domain_health_check_gateway Example Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_map_encapsulation_domain_health_check_gateway
-    a10_cgnv6_map_encapsulation_domain_health_check_gateway:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_map_encapsulation_domain_health_check_gateway
+    a10.acos_axapi.a10_cgnv6_map_encapsulation_domain_health_check_gateway:
       state: "present"
       ipv6_address_list:
         - ipv6_gateway: "2001:0db8:85a3:0000:0000:8a2e:0370:7334"

--- a/examples/single_task/cgnv6/map_encapsulation/a10_cgnv6_map_encapsulation_fragmentation_inbound.yml
+++ b/examples/single_task/cgnv6/map_encapsulation/a10_cgnv6_map_encapsulation_fragmentation_inbound.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_map_encapsulation_fragmentation_inbound Example Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_map_encapsulation_fragmentation_inbound Example Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_map_encapsulation_fragmentation_inbound
-    a10_cgnv6_map_encapsulation_fragmentation_inbound:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_map_encapsulation_fragmentation_inbound
+    a10.acos_axapi.a10_cgnv6_map_encapsulation_fragmentation_inbound:
       state: "present"
       frag_action: "drop"
       df_set: "drop"

--- a/examples/single_task/cgnv6/map_encapsulation/a10_cgnv6_map_encapsulation_fragmentation_outbound.yml
+++ b/examples/single_task/cgnv6/map_encapsulation/a10_cgnv6_map_encapsulation_fragmentation_outbound.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_map_encapsulation_fragmentation_outbound Example Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_map_encapsulation_fragmentation_outbound Example Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_map_encapsulation_fragmentation_outbound
-    a10_cgnv6_map_encapsulation_fragmentation_outbound:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_map_encapsulation_fragmentation_outbound
+    a10.acos_axapi.a10_cgnv6_map_encapsulation_fragmentation_outbound:
       state: "present"
       frag_action: "drop"
       df_set: "drop"

--- a/examples/single_task/cgnv6/map_translation/a10_cgnv6_map_translation_default_domain.yml
+++ b/examples/single_task/cgnv6/map_translation/a10_cgnv6_map_translation_default_domain.yml
@@ -1,12 +1,7 @@
-- name: a10_cgnv6_map_translation_default_domain Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_map_translation_default_domain Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: localhost
   tasks:
-  - name: a10_cgnv6_map_translation_default_domain
-    a10_cgnv6_map_translation_default_domain:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_map_translation_default_domain
+    a10.acos_axapi.a10_cgnv6_map_translation_default_domain:
       state: "present"

--- a/examples/single_task/cgnv6/map_translation/a10_cgnv6_map_translation_domain.yml
+++ b/examples/single_task/cgnv6/map_translation/a10_cgnv6_map_translation_domain.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_map_translation_domain Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_map_translation_domain Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_map_translation_domain
-    a10_cgnv6_map_translation_domain:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_map_translation_domain
+    a10.acos_axapi.a10_cgnv6_map_translation_domain:
       state: "present"
       default_mapping_rule:
         rule_ipv6_prefix: "2001:0DB8:0000:000b::/64"

--- a/examples/single_task/cgnv6/map_translation/a10_cgnv6_map_translation_domain_basic_mapping_rule.yml
+++ b/examples/single_task/cgnv6/map_translation/a10_cgnv6_map_translation_domain_basic_mapping_rule.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_map_translation_domain_basic_mapping_rule Example Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_map_translation_domain_basic_mapping_rule Example Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_map_translation_domain_basic_mapping_rule.py
-    a10_cgnv6_map_translation_domain_basic_mapping_rule.py:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_map_translation_domain_basic_mapping_rule.py
+    a10.acos_axapi.a10_cgnv6_map_translation_domain_basic_mapping_rule.py:
       state: "present"
       rule_ipv4_address_port_settings: "prefix-addr"
       prefix_rule_list:

--- a/examples/single_task/cgnv6/map_translation/a10_cgnv6_map_translation_domain_basic_mapping_rule_prefix_rule.yml
+++ b/examples/single_task/cgnv6/map_translation/a10_cgnv6_map_translation_domain_basic_mapping_rule_prefix_rule.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_map_translation_domain_basic_mapping_rule_prefix_rule Example Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_map_translation_domain_basic_mapping_rule_prefix_rule Example Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_map_translation_domain_basic_mapping_rule_prefix_rule
-    a10_cgnv6_map_translation_domain_basic_mapping_rule_prefix_rule:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_map_translation_domain_basic_mapping_rule_prefix_rule
+    a10.acos_axapi.a10_cgnv6_map_translation_domain_basic_mapping_rule_prefix_rule:
       state: "present"
       name: "MapRule1"
       user_tag: "TestTag"

--- a/examples/single_task/cgnv6/map_translation/a10_cgnv6_map_translation_domain_default_mapping_rule.yml
+++ b/examples/single_task/cgnv6/map_translation/a10_cgnv6_map_translation_domain_default_mapping_rule.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_map_translation_domain_default_mapping_rule Example Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_map_translation_domain_default_mapping_rule Example Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_map_translation_domain_default_mapping_rule
-    a10_cgnv6_map_translation_domain_default_mapping_rule:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_map_translation_domain_default_mapping_rule
+    a10.acos_axapi.a10_cgnv6_map_translation_domain_default_mapping_rule:
       state: "present"
       rule_ipv6_prefix: "2001:0DB8:0000:000b::/64"
       domain_name: "MapTranslation"

--- a/examples/single_task/cgnv6/map_translation/a10_cgnv6_map_translation_domain_health_check_gateway.yml
+++ b/examples/single_task/cgnv6/map_translation/a10_cgnv6_map_translation_domain_health_check_gateway.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_map_translation_domain_health_check_gateway example playbook
+- name: a10.acos_axapi.a10_cgnv6_map_translation_domain_health_check_gateway example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: a10_cgnv6_map_translation_domain_health_check_gateway
-    a10_cgnv6_map_translation_domain_health_check_gateway:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_map_translation_domain_health_check_gateway
+    a10.acos_axapi.a10_cgnv6_map_translation_domain_health_check_gateway:
       ipv6_address_list:
         - ipv6_gateway: "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
       address_list:

--- a/examples/single_task/cgnv6/nat/a10_cgnv6_fixed_nat_user_quota.yml
+++ b/examples/single_task/cgnv6/nat/a10_cgnv6_fixed_nat_user_quota.yml
@@ -1,12 +1,7 @@
-- name: a10_cgnv6_fixed_nat_user_quota Example Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_fixed_nat_user_quota Example Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_fixed_nat_user_quota
-    a10_cgnv6_fixed_nat_user_quota:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: a10.acos_axapi.a10_cgnv6_fixed_nat_user_quota
+    a10.acos_axapi.a10_cgnv6_fixed_nat_user_quota:
       state: "present"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"

--- a/examples/single_task/cgnv6/nat/a10_cgnv6_nat64_prefix.yml
+++ b/examples/single_task/cgnv6/nat/a10_cgnv6_nat64_prefix.yml
@@ -1,13 +1,8 @@
-- name: a10_cgnv6_nat64_prefix
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_nat64_prefix
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_nat64_prefix
-    a10_cgnv6_nat64_prefix:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_nat64_prefix
+    a10.acos_axapi.a10_cgnv6_nat64_prefix:
       prefix_val: "2001:0DB8:0000:000b::/64"
       class_list: "TestClassList"

--- a/examples/single_task/cgnv6/nat/a10_cgnv6_nat_exclude_port_tcp.yml
+++ b/examples/single_task/cgnv6/nat/a10_cgnv6_nat_exclude_port_tcp.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_nat_exclude_port_tcp example playbook
+- name: a10.acos_axapi.a10_cgnv6_nat_exclude_port_tcp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_nat_exclude_port_tcp
-    a10_cgnv6_nat_exclude_port_tcp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_nat_exclude_port_tcp
+    a10.acos_axapi.a10_cgnv6_nat_exclude_port_tcp:
       port_list: 
         - port: "9000"
           port_end: "9010"

--- a/examples/single_task/cgnv6/nat/a10_cgnv6_nat_exclude_port_udp.yml
+++ b/examples/single_task/cgnv6/nat/a10_cgnv6_nat_exclude_port_udp.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_nat_exclude_port_udp example playbook
+- name: a10.acos_axapi.a10_cgnv6_nat_exclude_port_udp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_nat_exclude_port_tcp
-    a10_cgnv6_nat_exclude_port_udp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_nat_exclude_port_tcp
+    a10.acos_axapi.a10_cgnv6_nat_exclude_port_udp:
       port_list: 
         - port: "9000"
           port_end: "9010"

--- a/examples/single_task/cgnv6/nat/a10_cgnv6_nat_icmp.yml
+++ b/examples/single_task/cgnv6/nat/a10_cgnv6_nat_icmp.yml
@@ -1,13 +1,8 @@
-- name: a10_cgnv6_nat_icmp example playbook
+- name: a10.acos_axapi.a10_cgnv6_nat_icmp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_nat_icmp
-    a10_cgnv6_nat_icmp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_nat_icmp
+    a10.acos_axapi.a10_cgnv6_nat_icmp:
       always_source_nat_errors: "0"
       respond_to_ping: "true"

--- a/examples/single_task/cgnv6/nat/a10_cgnv6_nat_icmpv6.yml
+++ b/examples/single_task/cgnv6/nat/a10_cgnv6_nat_icmpv6.yml
@@ -1,13 +1,8 @@
-- name: a10_cgnv6_nat_icmpv6 example playbook
+- name: a10.acos_axapi.a10_cgnv6_nat_icmpv6 example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_nat_icmpv6
-    a10_cgnv6_nat_icmpv6:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_nat_icmpv6
+    a10.acos_axapi.a10_cgnv6_nat_icmpv6:
       partition: "shared"
       respond_to_ping: "true"

--- a/examples/single_task/cgnv6/nat/a10_cgnv6_nat_inside_source_static.yml
+++ b/examples/single_task/cgnv6/nat/a10_cgnv6_nat_inside_source_static.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_nat_inside_source_static example playbook
+- name: a10.acos_axapi.a10_cgnv6_nat_inside_source_static example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_nat_inside_source_static
-    a10_cgnv6_nat_inside_source_static:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_nat_inside_source_static
+    a10.acos_axapi.a10_cgnv6_nat_inside_source_static:
       partition: "MyPartition"
       vrid: "0"
       src_address: "10.10.10.2"

--- a/examples/single_task/cgnv6/nat/a10_cgnv6_nat_inside_source_statistics.yml
+++ b/examples/single_task/cgnv6/nat/a10_cgnv6_nat_inside_source_statistics.yml
@@ -1,12 +1,7 @@
-- name: a10_cgnv6_nat_inside_source_statistics Example Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_nat_inside_source_statistics Example Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_nat_inside_source_statistics
-    a10_cgnv6_nat_inside_source_statistics:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: a10.acos_axapi.a10_cgnv6_nat_inside_source_statistics
+    a10.acos_axapi.a10_cgnv6_nat_inside_source_statistics:
       state: "present"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"

--- a/examples/single_task/cgnv6/nat/a10_cgnv6_nat_pool.yml
+++ b/examples/single_task/cgnv6/nat/a10_cgnv6_nat_pool.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_nat_pool example playbook
+- name: a10.acos_axapi.a10_cgnv6_nat_pool example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_nat_pool
-    a10_cgnv6_nat_pool:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_nat_pool
+    a10.acos_axapi.a10_cgnv6_nat_pool:
       pool_name: "CGN_Dynamic"
       start_address: "192.0.2.11"
       end_address: "192.0.2.12"

--- a/examples/single_task/cgnv6/nat/a10_cgnv6_nat_pool_group.yml
+++ b/examples/single_task/cgnv6/nat/a10_cgnv6_nat_pool_group.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_nat_pool_group example playbook
+- name: a10.acos_axapi.a10_cgnv6_nat_pool_group example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_nat_pool_group
-    a10_cgnv6_nat_pool_group:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_nat_pool_group
+    a10.acos_axapi.a10_cgnv6_nat_pool_group:
       partition: "shared"
       member_list:
         - pool_name: "CGN_Dynamic"

--- a/examples/single_task/cgnv6/nat/a10_cgnv6_nat_shared_pool.yml
+++ b/examples/single_task/cgnv6/nat/a10_cgnv6_nat_shared_pool.yml
@@ -1,12 +1,7 @@
-- name: a10_cgnv6_nat_shared_pool example playbook
+- name: a10.acos_axapi.a10_cgnv6_nat_shared_pool example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_nat_shared_pool
-    a10_cgnv6_nat_shared_pool:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_nat_shared_pool
+    a10.acos_axapi.a10_cgnv6_nat_shared_pool:
       partition: "MyPartition"

--- a/examples/single_task/cgnv6/nat/a10_cgnv6_nat_shared_pool_group.yml
+++ b/examples/single_task/cgnv6/nat/a10_cgnv6_nat_shared_pool_group.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_nat_shared_pool_group example playbook
+- name: a10.acos_axapi.a10_cgnv6_nat_shared_pool_group example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_nat_shared_pool_group
-    a10_cgnv6_nat_shared_pool_group:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_nat_shared_pool_group
+    a10.acos_axapi.a10_cgnv6_nat_shared_pool_group:
       partition: "MyPartition"
       members: 
         uuid: "Nat_shared_pool"

--- a/examples/single_task/cgnv6/nat/a10_cgnv6_nat_shared_pool_group_members.yml
+++ b/examples/single_task/cgnv6/nat/a10_cgnv6_nat_shared_pool_group_members.yml
@@ -1,12 +1,7 @@
-- name: a10_cgnv6_nat_shared_pool_group_members Example Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_nat_shared_pool_group_members Example Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_nat_shared_pool_group_members
-    a10_cgnv6_nat_shared_pool_group_members:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: a10.acos_axapi.a10_cgnv6_nat_shared_pool_group_members
+    a10.acos_axapi.a10_cgnv6_nat_shared_pool_group_members:
       state: "present"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"

--- a/examples/single_task/cgnv6/nat46_stateless/a10_cgnv6_nat46_stateless_fragmentation_inbound.yml
+++ b/examples/single_task/cgnv6/nat46_stateless/a10_cgnv6_nat46_stateless_fragmentation_inbound.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_nat46_stateless_fragmentation_inbound example playbook
+- name: a10.acos_axapi.a10_cgnv6_nat46_stateless_fragmentation_inbound example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_nat46_stateless_fragmentation_inbound
-    a10_cgnv6_nat46_stateless_fragmentation_inbound:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_nat46_stateless_fragmentation_inbound
+    a10.acos_axapi.a10_cgnv6_nat46_stateless_fragmentation_inbound:
       partition: "MyPartition"
       action: "drop"
          

--- a/examples/single_task/cgnv6/nat46_stateless/a10_cgnv6_nat46_stateless_fragmentation_outbound.yml
+++ b/examples/single_task/cgnv6/nat46_stateless/a10_cgnv6_nat46_stateless_fragmentation_outbound.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_nat46_stateless_fragmentation_outbound example playbook
+- name: a10.acos_axapi.a10_cgnv6_nat46_stateless_fragmentation_outbound example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_nat46_stateless_fragmentation_outbound
-    a10_cgnv6_nat46_stateless_fragmentation_outbound:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_nat46_stateless_fragmentation_outbound
+    a10.acos_axapi.a10_cgnv6_nat46_stateless_fragmentation_outbound:
       partition: "MyPartition"
       uuid: "TestCgnNat46StatelessFragmentationOutbound"
       action: "drop"

--- a/examples/single_task/cgnv6/nat46_stateless/a10_cgnv6_nat46_stateless_global.yml
+++ b/examples/single_task/cgnv6/nat46_stateless/a10_cgnv6_nat46_stateless_global.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_nat46_stateless_global example playbook
+- name: a10.acos_axapi.a10_cgnv6_nat46_stateless_global example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_nat46_stateless_global
-    a10_cgnv6_nat46_stateless_global:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_nat46_stateless_global
+    a10.acos_axapi.a10_cgnv6_nat46_stateless_global:
       partition: "MyPartition"
       uuid: "TestCGNV6StatelessNat46Global"
       sampling_enable: 

--- a/examples/single_task/cgnv6/nat46_stateless/a10_cgnv6_nat46_stateless_prefix.yml
+++ b/examples/single_task/cgnv6/nat46_stateless/a10_cgnv6_nat46_stateless_prefix.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_nat46_stateless_prefix example playbook
+- name: a10.acos_axapi.a10_cgnv6_nat46_stateless_prefix example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_nat46_stateless_prefix
-    a10_cgnv6_nat46_stateless_prefix:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_nat46_stateless_prefix
+    a10.acos_axapi.a10_cgnv6_nat46_stateless_prefix:
       partition: "MyPartition"
       ipv6_prefix: "2001:0DB8:0000:000b:0000:0000:0000:0001/96"
       vrid: "0"

--- a/examples/single_task/cgnv6/nat46_stateless/a10_cgnv6_nat46_stateless_static_dest_mapping.yml
+++ b/examples/single_task/cgnv6/nat46_stateless/a10_cgnv6_nat46_stateless_static_dest_mapping.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_nat46_stateless_static_dest_mapping example playbook
+- name: a10.acos_axapi.a10_cgnv6_nat46_stateless_static_dest_mapping example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_nat46_stateless_static_dest_mapping
-    a10_cgnv6_nat46_stateless_static_dest_mapping:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_nat46_stateless_static_dest_mapping
+    a10.acos_axapi.a10_cgnv6_nat46_stateless_static_dest_mapping:
       partition: "MyPartition"
       count: "2"
       v6_address: "2001:0DB8:0000:000b:0000:0000:0000:0001"

--- a/examples/single_task/cgnv6/nat64/a10_cgnv6_nat64_alg_esp.yml
+++ b/examples/single_task/cgnv6/nat64/a10_cgnv6_nat64_alg_esp.yml
@@ -1,13 +1,8 @@
-- name: a10_cgnv6_nat64_alg_esp example playbook
+- name: a10.acos_axapi.a10_cgnv6_nat64_alg_esp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_nat64_alg_esp
-    a10_cgnv6_nat64_alg_esp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_nat64_alg_esp
+    a10.acos_axapi.a10_cgnv6_nat64_alg_esp:
       partition: "MyPartition"
       esp_enable: "enable"

--- a/examples/single_task/cgnv6/nat64/a10_cgnv6_nat64_alg_ftp.yml
+++ b/examples/single_task/cgnv6/nat64/a10_cgnv6_nat64_alg_ftp.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_nat64_alg_ftp example playbook
+- name: a10.acos_axapi.a10_cgnv6_nat64_alg_ftp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_nat64_alg_ftp
-    a10_cgnv6_nat64_alg_ftp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_nat64_alg_ftp
+    a10.acos_axapi.a10_cgnv6_nat64_alg_ftp:
       partition: "MyPartition"
       trans_epsv_to_pasv: "disable"
       trans_lprt_to_port: "disable"

--- a/examples/single_task/cgnv6/nat64/a10_cgnv6_nat64_alg_h323.yml
+++ b/examples/single_task/cgnv6/nat64/a10_cgnv6_nat64_alg_h323.yml
@@ -1,13 +1,8 @@
-- name: a10_cgnv6_nat64_alg_h323 example playbook
+- name: a10.acos_axapi.a10_cgnv6_nat64_alg_h323 example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_nat64_alg_h323
-    a10_cgnv6_nat64_alg_h323:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_nat64_alg_h323
+    a10.acos_axapi.a10_cgnv6_nat64_alg_h323:
       partition: "MyPartition"
       h323_enable: "enable"

--- a/examples/single_task/cgnv6/nat64/a10_cgnv6_nat64_alg_mgcp.yml
+++ b/examples/single_task/cgnv6/nat64/a10_cgnv6_nat64_alg_mgcp.yml
@@ -1,13 +1,8 @@
-- name: a10_cgnv6_nat64_alg_mgcp example playbook
+- name: a10.acos_axapi.a10_cgnv6_nat64_alg_mgcp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_nat64_alg_mgcp
-    a10_cgnv6_nat64_alg_mgcp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_nat64_alg_mgcp
+    a10.acos_axapi.a10_cgnv6_nat64_alg_mgcp:
       partition: "MyPartition"
       mgcp_enable: "enable"

--- a/examples/single_task/cgnv6/nat64/a10_cgnv6_nat64_alg_pptp.yml
+++ b/examples/single_task/cgnv6/nat64/a10_cgnv6_nat64_alg_pptp.yml
@@ -1,13 +1,8 @@
-- name: a10_cgnv6_nat64_alg_pptp example playbook
+- name: a10.acos_axapi.a10_cgnv6_nat64_alg_pptp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_nat64_alg_pptp
-    a10_cgnv6_nat64_alg_pptp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_nat64_alg_pptp
+    a10.acos_axapi.a10_cgnv6_nat64_alg_pptp:
       partition: "MyPartition"
       pptp_enable: "enable"

--- a/examples/single_task/cgnv6/nat64/a10_cgnv6_nat64_alg_rtsp.yml
+++ b/examples/single_task/cgnv6/nat64/a10_cgnv6_nat64_alg_rtsp.yml
@@ -1,13 +1,8 @@
-- name: a10_cgnv6_nat64_alg_rtsp example playbook
+- name: a10.acos_axapi.a10_cgnv6_nat64_alg_rtsp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_nat64_alg_rtsp
-    a10_cgnv6_nat64_alg_rtsp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_nat64_alg_rtsp
+    a10.acos_axapi.a10_cgnv6_nat64_alg_rtsp:
       partition: "MyPartition"
       rtsp_enable: "enable"

--- a/examples/single_task/cgnv6/nat64/a10_cgnv6_nat64_alg_sip.yml
+++ b/examples/single_task/cgnv6/nat64/a10_cgnv6_nat64_alg_sip.yml
@@ -1,13 +1,8 @@
-- name: a10_cgnv6_nat64_alg_sip example playbook
+- name: a10.acos_axapi.a10_cgnv6_nat64_alg_sip example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_nat64_alg_sip
-    a10_cgnv6_nat64_alg_sip:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_nat64_alg_sip
+    a10.acos_axapi.a10_cgnv6_nat64_alg_sip:
       partition: "MyPartition"
       sip_enable: "enable"

--- a/examples/single_task/cgnv6/nat64/a10_cgnv6_nat64_alg_tftp.yml
+++ b/examples/single_task/cgnv6/nat64/a10_cgnv6_nat64_alg_tftp.yml
@@ -1,13 +1,8 @@
-- name: a10_cgnv6_nat64_alg_tftp example playbook
+- name: a10.acos_axapi.a10_cgnv6_nat64_alg_tftp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_nat64_alg_tftp
-    a10_cgnv6_nat64_alg_tftp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_nat64_alg_tftp
+    a10.acos_axapi.a10_cgnv6_nat64_alg_tftp:
       partition: "MyPartition"
       tftp_enable: "enable"

--- a/examples/single_task/cgnv6/nat64/a10_cgnv6_nat64_enhanced_user_tracking.yml
+++ b/examples/single_task/cgnv6/nat64/a10_cgnv6_nat64_enhanced_user_tracking.yml
@@ -1,11 +1,6 @@
-- name: a10_cgnv6_nat64_enhanced_user_tracking example playbook
+- name: a10.acos_axapi.a10_cgnv6_nat64_enhanced_user_tracking example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_nat64_enhanced_user_tracking
-    a10_cgnv6_nat64_enhanced_user_tracking:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_nat64_enhanced_user_tracking
+    a10.acos_axapi.a10_cgnv6_nat64_enhanced_user_tracking:

--- a/examples/single_task/cgnv6/nat64/a10_cgnv6_nat64_fragmentation_df_bit_transparency.yml
+++ b/examples/single_task/cgnv6/nat64/a10_cgnv6_nat64_fragmentation_df_bit_transparency.yml
@@ -1,13 +1,8 @@
-- name: a10_cgnv6_nat64_fragmentation_df_bit_transparency example playbook
+- name: a10.acos_axapi.a10_cgnv6_nat64_fragmentation_df_bit_transparency example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_nat64_fragmentation_df_bit_transparency
-    a10_cgnv6_nat64_fragmentation_df_bit_transparency:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_nat64_fragmentation_df_bit_transparency
+    a10.acos_axapi.a10_cgnv6_nat64_fragmentation_df_bit_transparency:
       partition: "MyPartition"
       df_bit_value: "enable"

--- a/examples/single_task/cgnv6/nat64/a10_cgnv6_nat64_fragmentation_inbound.yml
+++ b/examples/single_task/cgnv6/nat64/a10_cgnv6_nat64_fragmentation_inbound.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_nat64_fragmentation_inbound example playbook
+- name: a10.acos_axapi.a10_cgnv6_nat64_fragmentation_inbound example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_nat64_fragmentation_inbound
-    a10_cgnv6_nat64_fragmentation_inbound:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_nat64_fragmentation_inbound
+    a10.acos_axapi.a10_cgnv6_nat64_fragmentation_inbound:
       partition: "MyPartition"
       frag_action: "drop"
       df_set: "drop"       

--- a/examples/single_task/cgnv6/nat64/a10_cgnv6_nat64_fragmentation_outbound.yml
+++ b/examples/single_task/cgnv6/nat64/a10_cgnv6_nat64_fragmentation_outbound.yml
@@ -1,13 +1,8 @@
-- name: a10_cgnv6_nat64_fragmentation_outbound example playbook
+- name: a10.acos_axapi.a10_cgnv6_nat64_fragmentation_outbound example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_nat64_fragmentation_outbound
-    a10_cgnv6_nat64_fragmentation_outbound:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_nat64_fragmentation_outbound
+    a10.acos_axapi.a10_cgnv6_nat64_fragmentation_outbound:
       partition: "MyPartition"
       frag_action: "drop"

--- a/examples/single_task/cgnv6/nat64/a10_cgnv6_nat64_full_cone_session.yml
+++ b/examples/single_task/cgnv6/nat64/a10_cgnv6_nat64_full_cone_session.yml
@@ -1,12 +1,7 @@
-- name: a10_cgnv6_nat64_full_cone_session example playbook
+- name: a10.acos_axapi.a10_cgnv6_nat64_full_cone_session example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_nat64_full_cone_session
-    a10_cgnv6_nat64_full_cone_session:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_nat64_full_cone_session
+    a10.acos_axapi.a10_cgnv6_nat64_full_cone_session:
       partition: "MyPartition"

--- a/examples/single_task/cgnv6/nat64/a10_cgnv6_nat64_global.yml
+++ b/examples/single_task/cgnv6/nat64/a10_cgnv6_nat64_global.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_nat64_global example playbook
+- name: a10.acos_axapi.a10_cgnv6_nat64_global example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_nat64_global
-    a10_cgnv6_nat64_global:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_nat64_global
+    a10.acos_axapi.a10_cgnv6_nat64_global:
       user_quota_prefix_length: "128"
       sampling_enable:
         - counters1: "all"

--- a/examples/single_task/cgnv6/nat64/a10_cgnv6_nat64_user_quota_session.yml
+++ b/examples/single_task/cgnv6/nat64/a10_cgnv6_nat64_user_quota_session.yml
@@ -1,12 +1,7 @@
-- name: a10_cgnv6_nat64_user_quota_session example playbook
+- name: a10.acos_axapi.a10_cgnv6_nat64_user_quota_session example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_nat64_user_quota_session
-    a10_cgnv6_nat64_user_quota_session:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_nat64_user_quota_session
+    a10.acos_axapi.a10_cgnv6_nat64_user_quota_session:
       partition: "MyPartition"

--- a/examples/single_task/cgnv6/nptv6/a10_cgnv6_nptv6_common.yml
+++ b/examples/single_task/cgnv6/nptv6/a10_cgnv6_nptv6_common.yml
@@ -1,13 +1,8 @@
-- name: a10_cgnv6_nptv6_common example playbook
+- name: a10.acos_axapi.a10_cgnv6_nptv6_common example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_nptv6_common
-    a10_cgnv6_nptv6_common:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_nptv6_common
+    a10.acos_axapi.a10_cgnv6_nptv6_common:
       partition: "MyPartition"
       send_icmpv6_on_error: "disable"

--- a/examples/single_task/cgnv6/nptv6/a10_cgnv6_nptv6_domain.yml
+++ b/examples/single_task/cgnv6/nptv6/a10_cgnv6_nptv6_domain.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_nptv6_domain example playbook
+- name: a10.acos_axapi.a10_cgnv6_nptv6_domain example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_nptv6_domain
-    a10_cgnv6_nptv6_domain:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_nptv6_domain
+    a10.acos_axapi.a10_cgnv6_nptv6_domain:
       name: "TestCgnNptv6Domain"
       user_tag: "TestTag"
       sampling_enable: 

--- a/examples/single_task/cgnv6/one_to_one_pool/a10_cgnv6_one_to_one_global.yml
+++ b/examples/single_task/cgnv6/one_to_one_pool/a10_cgnv6_one_to_one_global.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_one_to_one_global Example Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_one_to_one_global Example Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_one_to_one_global
-    a10_cgnv6_one_to_one_global:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_one_to_one_global
+    a10.acos_axapi.a10_cgnv6_one_to_one_global:
       state: "present"
       get_type: "single"
       sampling_enable:

--- a/examples/single_task/cgnv6/one_to_one_pool/a10_cgnv6_one_to_one_mapping.yml
+++ b/examples/single_task/cgnv6/one_to_one_pool/a10_cgnv6_one_to_one_mapping.yml
@@ -1,13 +1,8 @@
-- name: a10_cgnv6_one_to_one_mapping Example Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_one_to_one_mapping Example Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_one_to_one_mapping
-    a10_cgnv6_one_to_one_mapping:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_one_to_one_mapping
+    a10.acos_axapi.a10_cgnv6_one_to_one_mapping:
       state: "present"
       get_type: "single"

--- a/examples/single_task/cgnv6/one_to_one_pool/a10_cgnv6_one_to_one_pool.yml
+++ b/examples/single_task/cgnv6/one_to_one_pool/a10_cgnv6_one_to_one_pool.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_one_to_one_pool Example Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_one_to_one_pool Example Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_one_to_one_pool
-    a10_cgnv6_one_to_one_pool:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_one_to_one_pool
+    a10.acos_axapi.a10_cgnv6_one_to_one_pool:
       state: "present"
       get_type: "single"
       start_address: "10.10.7.15"

--- a/examples/single_task/cgnv6/one_to_one_pool/a10_cgnv6_one_to_one_pool_group.yml
+++ b/examples/single_task/cgnv6/one_to_one_pool/a10_cgnv6_one_to_one_pool_group.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_one_to_one_pool_group Example Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_one_to_one_pool_group Example Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_one_to_one_pool_group
-    a10_cgnv6_one_to_one_pool_group:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_one_to_one_pool_group
+    a10.acos_axapi.a10_cgnv6_one_to_one_pool_group:
       state: "present"
       get_type: "single"
       member_list:

--- a/examples/single_task/cgnv6/one_to_one_pool/a10_cgnv6_one_to_one_pool_group_member.yml
+++ b/examples/single_task/cgnv6/one_to_one_pool/a10_cgnv6_one_to_one_pool_group_member.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_one_to_one_pool_group_member Example Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_one_to_one_pool_group_member Example Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_one_to_one_pool_group_member
-    a10_cgnv6_one_to_one_pool_group_member:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_one_to_one_pool_group_member
+    a10.acos_axapi.a10_cgnv6_one_to_one_pool_group_member:
       state: "present"
       get_type: "single"
       pool_name: "MyPool"

--- a/examples/single_task/cgnv6/one_to_one_shared_pool/a10_cgnv6_one_to_one_shared_pool.yml
+++ b/examples/single_task/cgnv6/one_to_one_shared_pool/a10_cgnv6_one_to_one_shared_pool.yml
@@ -1,12 +1,7 @@
-- name: a10_cgnv6_one_to_one_shared_pool Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_one_to_one_shared_pool Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_one_to_one_shared_pool
-    a10_cgnv6_one_to_one_shared_pool:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_one_to_one_shared_pool
+    a10.acos_axapi.a10_cgnv6_one_to_one_shared_pool:
       state: "present"

--- a/examples/single_task/cgnv6/one_to_one_shared_pool/a10_cgnv6_one_to_one_shared_pool_group.yml
+++ b/examples/single_task/cgnv6/one_to_one_shared_pool/a10_cgnv6_one_to_one_shared_pool_group.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_one_to_one_shared_pool_group
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_one_to_one_shared_pool_group
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_one_to_one_shared_pool_group
-    a10_cgnv6_one_to_one_shared_pool_group:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_one_to_one_shared_pool_group
+    a10.acos_axapi.a10_cgnv6_one_to_one_shared_pool_group:
       state: "present"
       members:
         uuid: "abc" 

--- a/examples/single_task/cgnv6/one_to_one_shared_pool/a10_cgnv6_one_to_one_shared_pool_group_members.yml
+++ b/examples/single_task/cgnv6/one_to_one_shared_pool/a10_cgnv6_one_to_one_shared_pool_group_members.yml
@@ -1,13 +1,8 @@
-- name: a10_cgnv6_one_to_one_shared_pool_group_members
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_one_to_one_shared_pool_group_members
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_one_to_one_shared_pool_group_members
-    a10_cgnv6_one_to_one_shared_pool_group_members:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_one_to_one_shared_pool_group_members
+    a10.acos_axapi.a10_cgnv6_one_to_one_shared_pool_group_members:
       state: "present"
       get_type: "single"

--- a/examples/single_task/cgnv6/port/a10_cgnv6_port_batch_v1.yml
+++ b/examples/single_task/cgnv6/port/a10_cgnv6_port_batch_v1.yml
@@ -1,13 +1,8 @@
-- name: a10_cgnv6_port_batch_v1 Example Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_port_batch_v1 Example Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_port_batch_v1
-    a10_cgnv6_port_batch_v1:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_port_batch_v1
+    a10.acos_axapi.a10_cgnv6_port_batch_v1:
       state: "present"
       enable_port_batch_v1: "true"

--- a/examples/single_task/cgnv6/port/a10_cgnv6_port_list.yml
+++ b/examples/single_task/cgnv6/port/a10_cgnv6_port_list.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_port_list Example Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_port_list Example Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_port_list
-    a10_cgnv6_port_list:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_port_list
+    a10.acos_axapi.a10_cgnv6_port_list:
       state: "present"
       port_config:
       - translated_port: 8085

--- a/examples/single_task/cgnv6/scaleout/a10_cgnv6_scaleout_address_mapping.yml
+++ b/examples/single_task/cgnv6/scaleout/a10_cgnv6_scaleout_address_mapping.yml
@@ -1,11 +1,6 @@
-- name: a10_cgnv6_scaleout_address_mapping Example Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_scaleout_address_mapping Example Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_scaleout_address_mapping
-    a10_cgnv6_scaleout_address_mapping:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_scaleout_address_mapping
+    a10.acos_axapi.a10_cgnv6_scaleout_address_mapping:

--- a/examples/single_task/cgnv6/scaleout/a10_cgnv6_scaleout_nat_ip_hashing_scheme.yml
+++ b/examples/single_task/cgnv6/scaleout/a10_cgnv6_scaleout_nat_ip_hashing_scheme.yml
@@ -1,12 +1,7 @@
-- name: a10_cgnv6_scaleout_nat_ip_hashing_scheme Example Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_scaleout_nat_ip_hashing_scheme Example Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks: 
-  - name: a10_cgnv6_scaleout_nat_ip_hashing_scheme 
-    a10_cgnv6_scaleout_nat_ip_hashing_scheme: 
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_scaleout_nat_ip_hashing_scheme 
+    a10.acos_axapi.a10_cgnv6_scaleout_nat_ip_hashing_scheme: 
       hashing_type: "route-aggregation"

--- a/examples/single_task/cgnv6/sctp/a10_cgnv6_sctp_global.yml
+++ b/examples/single_task/cgnv6/sctp/a10_cgnv6_sctp_global.yml
@@ -1,11 +1,6 @@
-- name: a10_cgnv6_sctp_global example playbook
+- name: a10.acos_axapi.a10_cgnv6_sctp_global example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: a10_cgnv6_sctp_global
-    a10_cgnv6_sctp_global:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_sctp_global
+    a10.acos_axapi.a10_cgnv6_sctp_global:

--- a/examples/single_task/cgnv6/sctp/a10_cgnv6_sctp_permit_payload_protocol_protocol_id.yml
+++ b/examples/single_task/cgnv6/sctp/a10_cgnv6_sctp_permit_payload_protocol_protocol_id.yml
@@ -1,12 +1,7 @@
-- name: a10_cgnv6_sctp_permit_payload_protocol_protocol_id example playbook
+- name: a10.acos_axapi.a10_cgnv6_sctp_permit_payload_protocol_protocol_id example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: a10_cgnv6_sctp_permit_payload_protocol_protocol_id
-    a10_cgnv6_sctp_permit_payload_protocol_protocol_id:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_sctp_permit_payload_protocol_protocol_id
+    a10.acos_axapi.a10_cgnv6_sctp_permit_payload_protocol_protocol_id:
       id: "4"

--- a/examples/single_task/cgnv6/sctp/a10_cgnv6_sctp_permit_payload_protocol_protocol_name.yml
+++ b/examples/single_task/cgnv6/sctp/a10_cgnv6_sctp_permit_payload_protocol_protocol_name.yml
@@ -1,12 +1,7 @@
-- name: a10_cgnv6_sctp_permit_payload_protocol_protocol_name example playbook
+- name: a10.acos_axapi.a10_cgnv6_sctp_permit_payload_protocol_protocol_name example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: a10_cgnv6_sctp_permit_payload_protocol_protocol_name
-    a10_cgnv6_sctp_permit_payload_protocol_protocol_name:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_sctp_permit_payload_protocol_protocol_name
+    a10.acos_axapi.a10_cgnv6_sctp_permit_payload_protocol_protocol_name:
       protocol: "iua"

--- a/examples/single_task/cgnv6/sctp/a10_cgnv6_sctp_rate_limit_destination.yml
+++ b/examples/single_task/cgnv6/sctp/a10_cgnv6_sctp_rate_limit_destination.yml
@@ -1,13 +1,8 @@
-- name: a10_cgnv6_sctp_rate_limit_destination example playbook
+- name: a10.acos_axapi.a10_cgnv6_sctp_rate_limit_destination example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: a10_cgnv6_sctp_rate_limit_destination
-    a10_cgnv6_sctp_rate_limit_destination:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_sctp_rate_limit_destination
+    a10.acos_axapi.a10_cgnv6_sctp_rate_limit_destination:
       ip: "10.10.10.15"
       rate_limit: "200"

--- a/examples/single_task/cgnv6/sctp/a10_cgnv6_sctp_rate_limit_entries.yml
+++ b/examples/single_task/cgnv6/sctp/a10_cgnv6_sctp_rate_limit_entries.yml
@@ -1,11 +1,6 @@
-- name: a10_cgnv6_sctp_rate_limit_entries example playbook
+- name: a10.acos_axapi.a10_cgnv6_sctp_rate_limit_entries example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: a10_cgnv6_sctp_rate_limit_entries
-    a10_cgnv6_sctp_rate_limit_entries:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_sctp_rate_limit_entries
+    a10.acos_axapi.a10_cgnv6_sctp_rate_limit_entries:

--- a/examples/single_task/cgnv6/sctp/a10_cgnv6_sctp_rate_limit_source.yml
+++ b/examples/single_task/cgnv6/sctp/a10_cgnv6_sctp_rate_limit_source.yml
@@ -1,13 +1,8 @@
-- name: a10_cgnv6_sctp_rate_limit_source example playbook
+- name: a10.acos_axapi.a10_cgnv6_sctp_rate_limit_source example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: a10_cgnv6_sctp_rate_limit_source
-    a10_cgnv6_sctp_rate_limit_source:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_sctp_rate_limit_source
+    a10.acos_axapi.a10_cgnv6_sctp_rate_limit_source:
       ip: "10.10.10.15"
       rate_limit: "200"

--- a/examples/single_task/cgnv6/server/a10_cgnv6_server.yml
+++ b/examples/single_task/cgnv6/server/a10_cgnv6_server.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_server Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_server Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_server
-    a10_cgnv6_server.py:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_server
+    a10.acos_axapi.a10_cgnv6_server.py:
       state: "present"
       health_check_disable: "false"
       port_list:

--- a/examples/single_task/cgnv6/server/a10_cgnv6_server_port.yml
+++ b/examples/single_task/cgnv6/server/a10_cgnv6_server_port.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_server_port Example
+- name: a10.acos_axapi.a10_cgnv6_server_port Example
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: a10_cgnv6_server_port
-    a10_cgnv6_server_port: 
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_server_port
+    a10.acos_axapi.a10_cgnv6_server_port: 
       state: "present"
       get_type: "single"
       server_name: "s1"

--- a/examples/single_task/cgnv6/service_group/a10_cgnv6_service_group.yml
+++ b/examples/single_task/cgnv6/service_group/a10_cgnv6_service_group.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_service_group Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_service_group Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_service_group
-    a10_cgnv6_service_group:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_service_group
+    a10.acos_axapi.a10_cgnv6_service_group:
       state: "present"
       get_type: "single"
       shared_partition: "MyPartition"

--- a/examples/single_task/cgnv6/service_group/a10_cgnv6_service_group_member.yml
+++ b/examples/single_task/cgnv6/service_group/a10_cgnv6_service_group_member.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_service_group_member Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_service_group_member Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_service_group_member
-    a10_cgnv6_service_group_member: 
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_service_group_member
+    a10.acos_axapi.a10_cgnv6_service_group_member: 
       state: "present"
       partition: "shared"
       get_type: "single"

--- a/examples/single_task/cgnv6/sixrd/a10_cgnv6_sixrd_fragmentation_inbound.yml
+++ b/examples/single_task/cgnv6/sixrd/a10_cgnv6_sixrd_fragmentation_inbound.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_sixrd_fragmentation_inbound Example Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_sixrd_fragmentation_inbound Example Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_sixrd_fragmentation_inbound
-    a10_cgnv6_sixrd_fragmentation_inbound: 
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_sixrd_fragmentation_inbound
+    a10.acos_axapi.a10_cgnv6_sixrd_fragmentation_inbound: 
       partition: "MyPartition"
       get_type: "single"
       state: "present"

--- a/examples/single_task/cgnv6/sixrd/a10_cgnv6_sixrd_fragmentation_outbound.yml
+++ b/examples/single_task/cgnv6/sixrd/a10_cgnv6_sixrd_fragmentation_outbound.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_sixrd_fragmentation_outbound Example Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_sixrd_fragmentation_outbound Example Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks: 
-  - name: a10_cgnv6_sixrd_fragmentation_outbound
-    a10_cgnv6_sixrd_fragmentation_outbound: 
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_sixrd_fragmentation_outbound
+    a10.acos_axapi.a10_cgnv6_sixrd_fragmentation_outbound: 
       partition: "MyPartition"
       get_type: "single"
       state: "present"

--- a/examples/single_task/cgnv6/stateful_firewall/a10_cgnv6_stateful_firewall_alg_ftp.yml
+++ b/examples/single_task/cgnv6/stateful_firewall/a10_cgnv6_stateful_firewall_alg_ftp.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_stateful_firewall_alg_ftp example playbook
+- name: a10.acos_axapi.a10_cgnv6_stateful_firewall_alg_ftp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_stateful_firewall_alg_ftp
-    a10_cgnv6_stateful_firewall_alg_ftp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_stateful_firewall_alg_ftp
+    a10.acos_axapi.a10_cgnv6_stateful_firewall_alg_ftp:
       partition: "MyPartition"
       ftp_value: "disable"
       sampling_enable: 

--- a/examples/single_task/cgnv6/stateful_firewall/a10_cgnv6_stateful_firewall_alg_pptp.yml
+++ b/examples/single_task/cgnv6/stateful_firewall/a10_cgnv6_stateful_firewall_alg_pptp.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_stateful_firewall_alg_pptp example playbook
+- name: a10.acos_axapi.a10_cgnv6_stateful_firewall_alg_pptp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_stateful_firewall_alg_pptp
-    a10_cgnv6_stateful_firewall_alg_pptp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_stateful_firewall_alg_pptp
+    a10.acos_axapi.a10_cgnv6_stateful_firewall_alg_pptp:
       partition: "MyPartition"
       pptp_value: "disable"
       sampling_enable: 

--- a/examples/single_task/cgnv6/stateful_firewall/a10_cgnv6_stateful_firewall_alg_rtp.yml
+++ b/examples/single_task/cgnv6/stateful_firewall/a10_cgnv6_stateful_firewall_alg_rtp.yml
@@ -1,13 +1,8 @@
-- name: a10_cgnv6_stateful_firewall_alg_rtp example playbook
+- name: a10.acos_axapi.a10_cgnv6_stateful_firewall_alg_rtp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_stateful_firewall_alg_rtp
-    a10_cgnv6_stateful_firewall_alg_rtp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_stateful_firewall_alg_rtp
+    a10.acos_axapi.a10_cgnv6_stateful_firewall_alg_rtp:
       partition: "MyPartition"
       rtp_stun_timeout: "10"

--- a/examples/single_task/cgnv6/stateful_firewall/a10_cgnv6_stateful_firewall_alg_rtsp.yml
+++ b/examples/single_task/cgnv6/stateful_firewall/a10_cgnv6_stateful_firewall_alg_rtsp.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_stateful_firewall_alg_rtsp example playbook
+- name: a10.acos_axapi.a10_cgnv6_stateful_firewall_alg_rtsp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_stateful_firewall_alg_rtsp
-    a10_cgnv6_stateful_firewall_alg_rtsp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_stateful_firewall_alg_rtsp
+    a10.acos_axapi.a10_cgnv6_stateful_firewall_alg_rtsp:
       partition: "MyPartition"
       rtsp_value: "disable"
       sampling_enable: 

--- a/examples/single_task/cgnv6/stateful_firewall/a10_cgnv6_stateful_firewall_alg_sip.yml
+++ b/examples/single_task/cgnv6/stateful_firewall/a10_cgnv6_stateful_firewall_alg_sip.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_stateful_firewall_alg_sip example playbook
+- name: a10.acos_axapi.a10_cgnv6_stateful_firewall_alg_sip example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_stateful_firewall_alg_sip
-    a10_cgnv6_stateful_firewall_alg_sip:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_stateful_firewall_alg_sip
+    a10.acos_axapi.a10_cgnv6_stateful_firewall_alg_sip:
       partition: "MyPartition"
       sip_value: "disable"
       sampling_enable: 

--- a/examples/single_task/cgnv6/stateful_firewall/a10_cgnv6_stateful_firewall_alg_tftp.yml
+++ b/examples/single_task/cgnv6/stateful_firewall/a10_cgnv6_stateful_firewall_alg_tftp.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_stateful_firewall_alg_tftp example playbook
+- name: a10.acos_axapi.a10_cgnv6_stateful_firewall_alg_tftp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_stateful_firewall_alg_tftp
-    a10_cgnv6_stateful_firewall_alg_tftp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_stateful_firewall_alg_tftp
+    a10.acos_axapi.a10_cgnv6_stateful_firewall_alg_tftp:
       partition: "MyPartition"
       tftp_value: "disable"
       sampling_enable: 

--- a/examples/single_task/cgnv6/stateful_firewall/a10_cgnv6_stateful_firewall_endpoint_independent_filtering_tcp.yml
+++ b/examples/single_task/cgnv6/stateful_firewall/a10_cgnv6_stateful_firewall_endpoint_independent_filtering_tcp.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_stateful_firewall_endpoint_independent_filtering_tcp example playbook
+- name: a10.acos_axapi.a10_cgnv6_stateful_firewall_endpoint_independent_filtering_tcp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_stateful_firewall_endpoint_independent_filtering_tcp
-    a10_cgnv6_stateful_firewall_endpoint_independent_filtering_tcp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_stateful_firewall_endpoint_independent_filtering_tcp
+    a10.acos_axapi.a10_cgnv6_stateful_firewall_endpoint_independent_filtering_tcp:
       partition: "MyPartition"
       port_list:
         - port_end: "9000"

--- a/examples/single_task/cgnv6/stateful_firewall/a10_cgnv6_stateful_firewall_endpoint_independent_filtering_udp.yml
+++ b/examples/single_task/cgnv6/stateful_firewall/a10_cgnv6_stateful_firewall_endpoint_independent_filtering_udp.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_stateful_firewall_endpoint_independent_filtering_udp example playbook
+- name: a10.acos_axapi.a10_cgnv6_stateful_firewall_endpoint_independent_filtering_udp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_stateful_firewall_endpoint_independent_filtering_udp
-    a10_cgnv6_stateful_firewall_endpoint_independent_filtering_udp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_stateful_firewall_endpoint_independent_filtering_udp
+    a10.acos_axapi.a10_cgnv6_stateful_firewall_endpoint_independent_filtering_udp:
       partition: "MyPartition"
       port_list:
         - port_end: "9000"

--- a/examples/single_task/cgnv6/stateful_firewall/a10_cgnv6_stateful_firewall_global.yml
+++ b/examples/single_task/cgnv6/stateful_firewall/a10_cgnv6_stateful_firewall_global.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_stateful_firewall_global example playbook
+- name: a10.acos_axapi.a10_cgnv6_stateful_firewall_global example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_stateful_firewall_global
-    a10_cgnv6_stateful_firewall_global:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_stateful_firewall_global
+    a10.acos_axapi.a10_cgnv6_stateful_firewall_global:
       partition: "MyPartition"
       respond_to_user_mac: "false"
       stateful_firewall_value: "enable"

--- a/examples/single_task/cgnv6/stateful_firewall/a10_cgnv6_stateful_firewall_stun_timeout.yml
+++ b/examples/single_task/cgnv6/stateful_firewall/a10_cgnv6_stateful_firewall_stun_timeout.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_stateful_firewall_stun_timeout example playbook
+- name: a10.acos_axapi.a10_cgnv6_stateful_firewall_stun_timeout example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_stateful_firewall_stun_timeout
-    a10_cgnv6_stateful_firewall_stun_timeout:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_stateful_firewall_stun_timeout
+    a10.acos_axapi.a10_cgnv6_stateful_firewall_stun_timeout:
       partition: "MyPartition"
       port_end: "9000"
       stun_timeout_val_port_range: "3"

--- a/examples/single_task/cgnv6/stateful_firewall/a10_cgnv6_stateful_firewall_tcp_idle_timeout.yml
+++ b/examples/single_task/cgnv6/stateful_firewall/a10_cgnv6_stateful_firewall_tcp_idle_timeout.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_stateful_firewall_tcp_idle_timeout example playbook
+- name: a10.acos_axapi.a10_cgnv6_stateful_firewall_tcp_idle_timeout example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_stateful_firewall_tcp_idle_timeout
-    a10_cgnv6_stateful_firewall_tcp_idle_timeout:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_stateful_firewall_tcp_idle_timeout
+    a10.acos_axapi.a10_cgnv6_stateful_firewall_tcp_idle_timeout:
       partition: "MyPartition"
       port_end: "9000"
       idle_timeout_val_port_range: "500"

--- a/examples/single_task/cgnv6/stateful_firewall/a10_cgnv6_stateful_firewall_tcp_stun_timeout.yml
+++ b/examples/single_task/cgnv6/stateful_firewall/a10_cgnv6_stateful_firewall_tcp_stun_timeout.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_stateful_firewall_tcp_stun_timeout example playbook
+- name: a10.acos_axapi.a10_cgnv6_stateful_firewall_tcp_stun_timeout example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_stateful_firewall_tcp_stun_timeout
-    a10_cgnv6_stateful_firewall_tcp_stun_timeout:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_stateful_firewall_tcp_stun_timeout
+    a10.acos_axapi.a10_cgnv6_stateful_firewall_tcp_stun_timeout:
       partition: "MyPartition"
       port_end: "9000"
       stun_timeout_val_port_range: "3"

--- a/examples/single_task/cgnv6/stateful_firewall/a10_cgnv6_stateful_firewall_tcp_syn_timeout.yml
+++ b/examples/single_task/cgnv6/stateful_firewall/a10_cgnv6_stateful_firewall_tcp_syn_timeout.yml
@@ -1,13 +1,8 @@
-- name: a10_cgnv6_stateful_firewall_tcp_syn_timeout example playbook
+- name: a10.acos_axapi.a10_cgnv6_stateful_firewall_tcp_syn_timeout example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_stateful_firewall_tcp_syn_timeout
-    a10_cgnv6_stateful_firewall_tcp_syn_timeout:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_stateful_firewall_tcp_syn_timeout
+    a10.acos_axapi.a10_cgnv6_stateful_firewall_tcp_syn_timeout:
       partition: "MyPartition"
       syn_timeout_val: "3"

--- a/examples/single_task/cgnv6/stateful_firewall/a10_cgnv6_stateful_firewall_udp_idle_timeout.yml
+++ b/examples/single_task/cgnv6/stateful_firewall/a10_cgnv6_stateful_firewall_udp_idle_timeout.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_stateful_firewall_udp_idle_timeout example playbook
+- name: a10.acos_axapi.a10_cgnv6_stateful_firewall_udp_idle_timeout example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_stateful_firewall_udp_idle_timeout
-    a10_cgnv6_stateful_firewall_udp_idle_timeout:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_stateful_firewall_udp_idle_timeout
+    a10.acos_axapi.a10_cgnv6_stateful_firewall_udp_idle_timeout:
       partition: "MyPartition"
       port_end: "9000"
       idle_timeout_val_port_range: "500"

--- a/examples/single_task/cgnv6/stateful_firewall/a10_cgnv6_stateful_firewall_udp_stun_timeout.yml
+++ b/examples/single_task/cgnv6/stateful_firewall/a10_cgnv6_stateful_firewall_udp_stun_timeout.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_stateful_firewall_udp_stun_timeout example playbook
+- name: a10.acos_axapi.a10_cgnv6_stateful_firewall_udp_stun_timeout example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_stateful_firewall_udp_stun_timeout
-    a10_cgnv6_stateful_firewall_udp_stun_timeout:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_stateful_firewall_udp_stun_timeout
+    a10.acos_axapi.a10_cgnv6_stateful_firewall_udp_stun_timeout:
       partition: "MyPartition"
       port_end: "9000"
       stun_timeout_val_port_range: "3"

--- a/examples/single_task/cgnv6/stateful_firewall/a10_cgnv6_stateful_firewall_vrid.yml
+++ b/examples/single_task/cgnv6/stateful_firewall/a10_cgnv6_stateful_firewall_vrid.yml
@@ -1,13 +1,8 @@
-- name: a10_cgnv6_stateful_firewall_vrid example playbook
+- name: a10.acos_axapi.a10_cgnv6_stateful_firewall_vrid example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_cgnv6_stateful_firewall_vrid
-    a10_cgnv6_stateful_firewall_vrid:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_cgnv6_stateful_firewall_vrid
+    a10.acos_axapi.a10_cgnv6_stateful_firewall_vrid:
       partition: "MyPartition"
       vrid_value: "0"

--- a/examples/single_task/cgnv6/template/a10_cgnv6_template_dns.yml
+++ b/examples/single_task/cgnv6/template/a10_cgnv6_template_dns.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_template_dns
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_template_dns
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_template_dns
-    a10_cgnv6_template_dns:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_template_dns
+    a10.acos_axapi.a10_cgnv6_template_dns:
       state: "present"
       name: "MyName"
       class_list:

--- a/examples/single_task/cgnv6/template/a10_cgnv6_template_dns_class_list.yml
+++ b/examples/single_task/cgnv6/template/a10_cgnv6_template_dns_class_list.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_template_dns_class_list Example Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_template_dns_class_list Example Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_template_dns_class_list
-    a10_cgnv6_template_dns_class_list:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_template_dns_class_list
+    a10.acos_axapi.a10_cgnv6_template_dns_class_list:
       state: "present"
       lid_list:
         - action_value: "dns-cache-disable"

--- a/examples/single_task/cgnv6/template/a10_cgnv6_template_dns_class_list_lid.yml
+++ b/examples/single_task/cgnv6/template/a10_cgnv6_template_dns_class_list_lid.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_template_dns_class_list_lid Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_template_dns_class_list_lid Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_template_dns_class_list_lid
-    a10_cgnv6_template_dns_class_list_lid:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_template_dns_class_list_lid
+    a10.acos_axapi.a10_cgnv6_template_dns_class_list_lid:
       state: "present"
       dns_name: "TestDns"
       action_value: "dns-cache-disable"

--- a/examples/single_task/cgnv6/template/a10_cgnv6_template_dns_dns64.yml
+++ b/examples/single_task/cgnv6/template/a10_cgnv6_template_dns_dns64.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_template_dns_dns64 Example Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_template_dns_dns64 Example Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_template_dns_dns64
-    a10_cgnv6_template_dns_dns64:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_template_dns_dns64
+    a10.acos_axapi.a10_cgnv6_template_dns_dns64:
       state: "present"
       deep_check_rr_disable: "false"
       answer_only_disable: "false"

--- a/examples/single_task/cgnv6/template/a10_cgnv6_template_http_alg.yml
+++ b/examples/single_task/cgnv6/template/a10_cgnv6_template_http_alg.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_template_http_alg Example Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_template_http_alg Example Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_template_http_alg
-    a10_cgnv6_template_http_alg:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_template_http_alg
+    a10.acos_axapi.a10_cgnv6_template_http_alg:
       state: "present"
       header_name_client_ip: "X-Forwarded-For"
       name: "HttpTemplate"

--- a/examples/single_task/cgnv6/template/a10_cgnv6_template_logging.yml
+++ b/examples/single_task/cgnv6/template/a10_cgnv6_template_logging.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_template_logging Example Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_template_logging Example Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_template_logging
-    a10_cgnv6_template_logging:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_template_logging
+    a10.acos_axapi.a10_cgnv6_template_logging:
       state: "present"
       name: "TemplateLog1"
       include_http:

--- a/examples/single_task/cgnv6/template/a10_cgnv6_template_logging_disable_log_by_destination2.yml
+++ b/examples/single_task/cgnv6/template/a10_cgnv6_template_logging_disable_log_by_destination2.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_template_logging_disable_log_by_destination Example Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_template_logging_disable_log_by_destination Example Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_template_logging_disable_log_by_destination
-    a10_cgnv6_template_logging_disable_log_by_destination:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_template_logging_disable_log_by_destination
+    a10.acos_axapi.a10_cgnv6_template_logging_disable_log_by_destination:
       state: "present"
       icmp: "true"
       logging_name: "LsnTemplate1"

--- a/examples/single_task/cgnv6/template/a10_cgnv6_template_logging_source_address.yml
+++ b/examples/single_task/cgnv6/template/a10_cgnv6_template_logging_source_address.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_template_logging_source_address Example Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_template_logging_source_address Example Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_template_logging_source_address
-    a10_cgnv6_template_logging_source_address:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_template_logging_source_address
+    a10.acos_axapi.a10_cgnv6_template_logging_source_address:
       state: "present"
       ip: "10.10.10.15"
       ipv6: "2001:0db8:85a3:0000:0000:8a2e:0370:7334"

--- a/examples/single_task/cgnv6/template/a10_cgnv6_template_pcp.yml
+++ b/examples/single_task/cgnv6/template/a10_cgnv6_template_pcp.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_template_pcp
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_template_pcp
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_template_pcp
-    a10_cgnv6_template_pcp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_template_pcp
+    a10.acos_axapi.a10_cgnv6_template_pcp:
       state: "present"
       source_ipv6: "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
       allow_third_party_from_lan: "false"

--- a/examples/single_task/cgnv6/template/a10_cgnv6_template_policy.yml
+++ b/examples/single_task/cgnv6/template/a10_cgnv6_template_policy.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_template_policy Example Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_template_policy Example Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_template_policy
-    a10_cgnv6_template_policy:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_template_policy
+    a10.acos_axapi.a10_cgnv6_template_policy:
       state: "present"
       name: "TemplatePolicy1"
       user_tag: "TestTag"

--- a/examples/single_task/cgnv6/template/a10_cgnv6_template_policy_class_list.yml
+++ b/examples/single_task/cgnv6/template/a10_cgnv6_template_policy_class_list.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_template_policy_class_list Example Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_template_policy_class_list Example Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_template_policy_class_list
-    a10_cgnv6_template_policy_class_list:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_template_policy_class_list
+    a10.acos_axapi.a10_cgnv6_template_policy_class_list:
       state: "present"
       policy_name: "TemplatePolicy1"
       lid_list:

--- a/examples/single_task/cgnv6/template/a10_cgnv6_template_policy_class_list_lid.yml
+++ b/examples/single_task/cgnv6/template/a10_cgnv6_template_policy_class_list_lid.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_template_policy_class_list_lid Example Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_template_policy_class_list_lid Example Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_template_policy_class_list_lid
-    a10_cgnv6_template_policy_class_list_lid:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_template_policy_class_list_lid
+    a10.acos_axapi.a10_cgnv6_template_policy_class_list_lid:
       state: "present"
       policy_name: "TemplatePolicy1"
       request_limit: 1000

--- a/examples/single_task/cgnv6/transition/a10_cgnv6_translation.yml
+++ b/examples/single_task/cgnv6/transition/a10_cgnv6_translation.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_translation Example Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_translation Example Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_translation
-    a10_cgnv6_translation:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_translation
+    a10.acos_axapi.a10_cgnv6_translation:
       state: "present"
       tcp_timeout: 300
       udp_timeout: 300

--- a/examples/single_task/cgnv6/transition/a10_cgnv6_translation_service_timeout.yml
+++ b/examples/single_task/cgnv6/transition/a10_cgnv6_translation_service_timeout.yml
@@ -1,14 +1,9 @@
-- name: a10_cgnv6_translation_service_timeout Example Playbook
-  hosts: localhost
+- name: a10.acos_axapi.a10_cgnv6_translation_service_timeout Example Playbook
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
-  - name: a10_cgnv6_translation_service_timeout
-    a10_cgnv6_translation_service_timeout:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_cgnv6_translation_service_timeout
+    a10.acos_axapi.a10_cgnv6_translation_service_timeout:
       state: "present"
       service_type: "tcp"
       timeout_val: 3

--- a/examples/single_task/enable_password/a10_enable_password.yaml
+++ b/examples/single_task/enable_password/a10_enable_password.yaml
@@ -1,12 +1,7 @@
 - name: Change enable password example 
   connection: local
-  hosts: all 
+  hosts: "{{desired_inventory_group}}" 
   tasks:
   - name: Change password for enable command
-    a10_enable_password:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_protocol: "{{ a10_protocol }}"
-      a10_port: "{{ a10_port }}"
+    a10.acos_axapi.a10_enable_password:
       password: "supersecret"

--- a/examples/single_task/file_import_export/aflex/a10_export.yaml
+++ b/examples/single_task/file_import_export/aflex/a10_export.yaml
@@ -1,13 +1,8 @@
 - name: A10 export aflex example 
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
   - name: Export aflex files 
-    a10_export:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_protocol: "{{ a10_protocol }}"
-      a10_port: "{{ a10_port }}"
+    a10.acos_axapi.a10_export:
       aflex: "aflex_scirpt_name"
       remote_file: "scp://username:password@host:/path/to/file"

--- a/examples/single_task/file_import_export/aflex/a10_import.yaml
+++ b/examples/single_task/file_import_export/aflex/a10_import.yaml
@@ -1,13 +1,8 @@
 - name: A10 import aflex example 
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
   - name: Import aflex files 
-    a10_import:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_protocol: "{{ a10_protocol }}"
-      a10_port: "{{ a10_port }}"
+    a10.acos_axapi.a10_import:
       aflex: "aflex_script_name"
       remote_file: "scp://username:password@host:/path/to/file"

--- a/examples/single_task/file_import_export/class_list/a10_export.yaml
+++ b/examples/single_task/file_import_export/class_list/a10_export.yaml
@@ -1,13 +1,8 @@
 - name: A10 export class-list example  
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
   - name: Export class-list filename 
-    a10_export:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_protocol: "{{ a10_protocol }}"
-      a10_port: "{{ a10_port }}"
+    a10.acos_axapi.a10_export:
       class_list: "class_list_filename"
       remote_file: "scp://username:password@host:/path/to/file"

--- a/examples/single_task/file_import_export/class_list/a10_import.yaml
+++ b/examples/single_task/file_import_export/class_list/a10_import.yaml
@@ -1,13 +1,8 @@
 - name: A10 class-list import example
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
   - name: Import class-list file
-    a10_import:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_protocol: "{{ a10_protocol }}"
-      a10_port: "{{ a10_port }}"
+    a10.acos_axapi.a10_import:
       class_list: "class_list_filename"
       remote_file: "scp://username:password@host:/path/to/file"

--- a/examples/single_task/file_import_export/ssl_cert/a10_export.yaml
+++ b/examples/single_task/file_import_export/ssl_cert/a10_export.yaml
@@ -1,13 +1,8 @@
 - name: A10 export ssl-cert example
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
   - name: Export ssl-cert file 
-    a10_export:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_protocol: "{{ a10_protocol }}"
-      a10_port: "{{ a10_port }}"
+    a10.acos_axapi.a10_export:
       ssl_cert: "ssl_cert_filename"
       remote_file: "scp://username:password@host:/path/to/file"

--- a/examples/single_task/file_import_export/ssl_cert/a10_import.yaml
+++ b/examples/single_task/file_import_export/ssl_cert/a10_import.yaml
@@ -1,13 +1,8 @@
 - name: A10 import ssl-cert example
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
   - name: Import ssl-cert file 
-    a10_import:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_protocol: "{{ a10_protocol }}"
-      a10_port: "{{ a10_port }}"
+    a10.acos_axapi.a10_import:
       ssl_cert: "ssl_cert_filename"
       remote_file: "scp://username:password@host:/path/to/file"

--- a/examples/single_task/glm/a10_glm.yaml
+++ b/examples/single_task/glm/a10_glm.yaml
@@ -1,13 +1,8 @@
 - name: Set glm token example 
   connection: local
-  hosts: all 
+  hosts: "{{desired_inventory_group}}" 
   tasks:
   - name: Authenticate via token
-    a10_glm:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_protocol: "{{ a10_protocol }}"
-      a10_port: "{{ a10_port }}"
+    a10.acos_axapi.a10_glm:
       token: "EXAMPLE_TOKEN"
       use_mgmt_port: 0

--- a/examples/single_task/glm/a10_glm_send.yaml
+++ b/examples/single_task/glm/a10_glm_send.yaml
@@ -1,14 +1,9 @@
 - name: Request license example 
   connection: local
-  hosts: all 
+  hosts: "{{desired_inventory_group}}" 
   tasks:
   - name: Request license
-    a10_glm:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_protocol: "{{ a10_protocol }}"
-      a10_port: "{{ a10_port }}"
+    a10.acos_axapi.a10_glm:
       use_mgmt_port: 0
       send:
         license-request: 1

--- a/examples/single_task/harmony/a10_harmony_controller_profile_create.yaml
+++ b/examples/single_task/harmony/a10_harmony_controller_profile_create.yaml
@@ -1,15 +1,10 @@
 
-- name: Create a10_harmony_controller_profile example playbook
+- name: Create a10.acos_axapi.a10_harmony_controller_profile example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_harmony_controller_profile instance
-    a10_harmony_controller_profile:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_harmony_controller_profile instance
+    a10.acos_axapi.a10_harmony_controller_profile:
       host: "10.0.0.2" # mgmt IP
       port: "8443"     #fixed port
       user_name: "test-profile" #profile name of harmony controller

--- a/examples/single_task/harmony/a10_harmony_controller_profile_delete.yaml
+++ b/examples/single_task/harmony/a10_harmony_controller_profile_delete.yaml
@@ -1,15 +1,10 @@
-- name: Delete a10_harmony_controller_profile example playbook
+- name: Delete a10.acos_axapi.a10_harmony_controller_profile example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_harmony_controller_profile instance
-    a10_harmony_controller_profile:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_harmony_controller_profile instance
+    a10.acos_axapi.a10_harmony_controller_profile:
       state: absent
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
       host: "10.0.0.2" # mgmt IP
       port: "8443"     #fixed port
       user_name: "test-profile" #profile name of harmony controller

--- a/examples/single_task/harmony/a10_harmony_controller_profile_update.yaml
+++ b/examples/single_task/harmony/a10_harmony_controller_profile_update.yaml
@@ -1,16 +1,11 @@
 
-- name: Update a10_harmony_controller_profile example playbook
+- name: Update a10.acos_axapi.a10_harmony_controller_profile example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_harmony_controller_profile instance
-    a10_harmony_controller_profile:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_harmony_controller_profile instance
+    a10.acos_axapi.a10_harmony_controller_profile:
       state: present
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
       host: "10.0.0.2" # mgmt IP
       port: "8443"     #fixed port
       user_name: "test-profile" #profile name of harmony controller

--- a/examples/single_task/health_monitor/a10_health_monitor_create.yaml
+++ b/examples/single_task/health_monitor/a10_health_monitor_create.yaml
@@ -1,14 +1,9 @@
-- name: Create a10_health_monitor example playbook
+- name: Create a10.acos_axapi.a10_health_monitor example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_health_monitor instance
-    a10_health_monitor:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}" 
+  - name: Create a10.acos_axapi.a10_health_monitor instance
+    a10.acos_axapi.a10_health_monitor:
       up_retry: 1
       retry: 1
       method:

--- a/examples/single_task/health_monitor/a10_health_monitor_delete.yaml
+++ b/examples/single_task/health_monitor/a10_health_monitor_delete.yaml
@@ -1,14 +1,9 @@
-- name: Delete a10_health_monitor example playbook
+- name: Delete a10.acos_axapi.a10_health_monitor example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_health_monitor instance
-    a10_health_monitor:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Delete a10.acos_axapi.a10_health_monitor instance
+    a10.acos_axapi.a10_health_monitor:
       state: absent
       up_retry: 1
       retry: 1

--- a/examples/single_task/health_monitor/a10_health_monitor_update.yaml
+++ b/examples/single_task/health_monitor/a10_health_monitor_update.yaml
@@ -1,14 +1,9 @@
-- name: Update a10_health_monitor example playbook
+- name: Update a10.acos_axapi.a10_health_monitor example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_health_monitor instance
-    a10_health_monitor:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Update a10.acos_axapi.a10_health_monitor instance
+    a10.acos_axapi.a10_health_monitor:
       state: present
       up_retry: 1
       retry: 1

--- a/examples/single_task/interface/a10_interface_a10loopb.yaml
+++ b/examples/single_task/interface/a10_interface_a10loopb.yaml
@@ -1,33 +1,24 @@
 
 
-- name: Create a10_interface_a10loopb example playbook
+- name: Create a10.acos_axapi.a10_interface_a10loopb example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_interface_a10loopb instance
-    a10_interface_a10loopb:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_interface_a10loopb instance
+    a10.acos_axapi.a10_interface_a10loopb:
 
-- name: Update a10_interface_a10loopb example playbook
+- name: Update a10.acos_axapi.a10_interface_a10loopb example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_interface_a10loopb instance
-    a10_interface_a10loopb:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_interface_a10loopb instance
+    a10.acos_axapi.a10_interface_a10loopb:
       state: present
 
-- name: Delete a10_interface_a10loopb example playbook
+- name: Delete a10.acos_axapi.a10_interface_a10loopb example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_interface_a10loopb instance
-    a10_interface_a10loopb:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_interface_a10loopb instance
+    a10.acos_axapi.a10_interface_a10loopb:
       state: absent

--- a/examples/single_task/interface/a10_interface_dhcp.yaml
+++ b/examples/single_task/interface/a10_interface_dhcp.yaml
@@ -1,15 +1,10 @@
 - name: Assign interface IP address
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
   - name: Assign interface IP address
-    a10_interface_ethernet:
+    a10.acos_axapi.a10_interface_ethernet:
       state: "{{ state }}"
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
       ip:
         dhcp: "true"
       ifnum: 1

--- a/examples/single_task/interface/a10_interface_ethernet.yaml
+++ b/examples/single_task/interface/a10_interface_ethernet.yaml
@@ -1,29 +1,23 @@
 
 
-- name: Create a10_interface_ethernet example playbook
+- name: Create a10.acos_axapi.a10_interface_ethernet example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_interface_ethernet instance
-    a10_interface_ethernet:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_interface_ethernet instance
+    a10.acos_axapi.a10_interface_ethernet:
       ifnum: None
       load_interval: 5
       duplexity: auto
       speed: auto
       action: disable
 
-- name: Update a10_interface_ethernet example playbook
+- name: Update a10.acos_axapi.a10_interface_ethernet example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_interface_ethernet instance
-    a10_interface_ethernet:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_interface_ethernet instance
+    a10.acos_axapi.a10_interface_ethernet:
       state: present
       ifnum: None
       load_interval: 5
@@ -31,15 +25,12 @@
       speed: auto
       action: disable
 
-- name: Delete a10_interface_ethernet example playbook
+- name: Delete a10.acos_axapi.a10_interface_ethernet example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_interface_ethernet instance
-    a10_interface_ethernet:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_interface_ethernet instance
+    a10.acos_axapi.a10_interface_ethernet:
       state: absent
       ifnum: None
       load_interval: 5

--- a/examples/single_task/interface/a10_interface_ethernet_ip_ospf_ospf_ip.yaml
+++ b/examples/single_task/interface/a10_interface_ethernet_ip_ospf_ospf_ip.yaml
@@ -1,14 +1,11 @@
 
 
-- name: Create a10_interface_ethernet_ip_ospf_ospf_ip example playbook
+- name: Create a10.acos_axapi.a10_interface_ethernet_ip_ospf_ospf_ip example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_interface_ethernet_ip_ospf_ospf_ip instance
-    a10_interface_ethernet_ip_ospf_ospf_ip:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_interface_ethernet_ip_ospf_ospf_ip instance
+    a10.acos_axapi.a10_interface_ethernet_ip_ospf_ospf_ip:
       ip_addr: 10.0.0.1
       dead_interval: 1
       hello_interval: 1
@@ -16,15 +13,12 @@
       retransmit_interval: 1
       transmit_delay: 1
 
-- name: Update a10_interface_ethernet_ip_ospf_ospf_ip example playbook
+- name: Update a10.acos_axapi.a10_interface_ethernet_ip_ospf_ospf_ip example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_interface_ethernet_ip_ospf_ospf_ip instance
-    a10_interface_ethernet_ip_ospf_ospf_ip:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_interface_ethernet_ip_ospf_ospf_ip instance
+    a10.acos_axapi.a10_interface_ethernet_ip_ospf_ospf_ip:
       state: present
       ip_addr: 10.0.0.1
       dead_interval: 1
@@ -33,15 +27,12 @@
       retransmit_interval: 1
       transmit_delay: 1
 
-- name: Delete a10_interface_ethernet_ip_ospf_ospf_ip example playbook
+- name: Delete a10.acos_axapi.a10_interface_ethernet_ip_ospf_ospf_ip example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_interface_ethernet_ip_ospf_ospf_ip instance
-    a10_interface_ethernet_ip_ospf_ospf_ip:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_interface_ethernet_ip_ospf_ospf_ip instance
+    a10.acos_axapi.a10_interface_ethernet_ip_ospf_ospf_ip:
       state: absent
       ip_addr: 10.0.0.1
       dead_interval: 1

--- a/examples/single_task/interface/a10_interface_ethernet_nptv6_domain.yaml
+++ b/examples/single_task/interface/a10_interface_ethernet_nptv6_domain.yaml
@@ -1,39 +1,30 @@
 
 
-- name: Create a10_interface_ethernet_nptv6_domain example playbook
+- name: Create a10.acos_axapi.a10_interface_ethernet_nptv6_domain example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_interface_ethernet_nptv6_domain instance
-    a10_interface_ethernet_nptv6_domain:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_interface_ethernet_nptv6_domain instance
+    a10.acos_axapi.a10_interface_ethernet_nptv6_domain:
       domain_name: NO_EXAMPLE
       bind_type: inside
 
-- name: Update a10_interface_ethernet_nptv6_domain example playbook
+- name: Update a10.acos_axapi.a10_interface_ethernet_nptv6_domain example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_interface_ethernet_nptv6_domain instance
-    a10_interface_ethernet_nptv6_domain:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_interface_ethernet_nptv6_domain instance
+    a10.acos_axapi.a10_interface_ethernet_nptv6_domain:
       state: present
       domain_name: NO_EXAMPLE
       bind_type: inside
 
-- name: Delete a10_interface_ethernet_nptv6_domain example playbook
+- name: Delete a10.acos_axapi.a10_interface_ethernet_nptv6_domain example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_interface_ethernet_nptv6_domain instance
-    a10_interface_ethernet_nptv6_domain:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_interface_ethernet_nptv6_domain instance
+    a10.acos_axapi.a10_interface_ethernet_nptv6_domain:
       state: absent
       domain_name: NO_EXAMPLE
       bind_type: inside

--- a/examples/single_task/interface/a10_interface_ethernet_trunk_group.yaml
+++ b/examples/single_task/interface/a10_interface_ethernet_trunk_group.yaml
@@ -1,43 +1,34 @@
 
 
-- name: Create a10_interface_ethernet_trunk_group example playbook
+- name: Create a10.acos_axapi.a10_interface_ethernet_trunk_group example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_interface_ethernet_trunk_group instance
-    a10_interface_ethernet_trunk_group:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_interface_ethernet_trunk_group instance
+    a10.acos_axapi.a10_interface_ethernet_trunk_group:
       trunk_number: 1
       type: static
       mode: active
       timeout: long
 
-- name: Update a10_interface_ethernet_trunk_group example playbook
+- name: Update a10.acos_axapi.a10_interface_ethernet_trunk_group example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_interface_ethernet_trunk_group instance
-    a10_interface_ethernet_trunk_group:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_interface_ethernet_trunk_group instance
+    a10.acos_axapi.a10_interface_ethernet_trunk_group:
       state: present
       trunk_number: 1
       type: static
       mode: active
       timeout: long
 
-- name: Delete a10_interface_ethernet_trunk_group example playbook
+- name: Delete a10.acos_axapi.a10_interface_ethernet_trunk_group example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_interface_ethernet_trunk_group instance
-    a10_interface_ethernet_trunk_group:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_interface_ethernet_trunk_group instance
+    a10.acos_axapi.a10_interface_ethernet_trunk_group:
       state: absent
       trunk_number: 1
       type: static

--- a/examples/single_task/interface/a10_interface_ip.yaml
+++ b/examples/single_task/interface/a10_interface_ip.yaml
@@ -1,14 +1,9 @@
 - name: Assign interface IP address
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
   - name: Assign interface IP address
-    a10_interface_ethernet:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+    a10.acos_axapi.a10_interface_ethernet:
       state: "present"
       ip:
         address_list:

--- a/examples/single_task/interface/a10_interface_lif.yaml
+++ b/examples/single_task/interface/a10_interface_lif.yaml
@@ -1,39 +1,30 @@
 
 
-- name: Create a10_interface_lif example playbook
+- name: Create a10.acos_axapi.a10_interface_lif example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_interface_lif instance
-    a10_interface_lif:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_interface_lif instance
+    a10.acos_axapi.a10_interface_lif:
       ifnum: 1
       action: enable
 
-- name: Update a10_interface_lif example playbook
+- name: Update a10.acos_axapi.a10_interface_lif example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_interface_lif instance
-    a10_interface_lif:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_interface_lif instance
+    a10.acos_axapi.a10_interface_lif:
       state: present
       ifnum: 1
       action: enable
 
-- name: Delete a10_interface_lif example playbook
+- name: Delete a10.acos_axapi.a10_interface_lif example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_interface_lif instance
-    a10_interface_lif:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_interface_lif instance
+    a10.acos_axapi.a10_interface_lif:
       state: absent
       ifnum: 1
       action: enable

--- a/examples/single_task/interface/a10_interface_lif_ip_ospf_ospf_ip.yaml
+++ b/examples/single_task/interface/a10_interface_lif_ip_ospf_ospf_ip.yaml
@@ -1,14 +1,11 @@
 
 
-- name: Create a10_interface_lif_ip_ospf_ospf_ip example playbook
+- name: Create a10.acos_axapi.a10_interface_lif_ip_ospf_ospf_ip example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_interface_lif_ip_ospf_ospf_ip instance
-    a10_interface_lif_ip_ospf_ospf_ip:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_interface_lif_ip_ospf_ospf_ip instance
+    a10.acos_axapi.a10_interface_lif_ip_ospf_ospf_ip:
       ip_addr: 10.0.0.1
       dead_interval: 1
       hello_interval: 1
@@ -16,15 +13,12 @@
       retransmit_interval: 1
       transmit_delay: 1
 
-- name: Update a10_interface_lif_ip_ospf_ospf_ip example playbook
+- name: Update a10.acos_axapi.a10_interface_lif_ip_ospf_ospf_ip example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_interface_lif_ip_ospf_ospf_ip instance
-    a10_interface_lif_ip_ospf_ospf_ip:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_interface_lif_ip_ospf_ospf_ip instance
+    a10.acos_axapi.a10_interface_lif_ip_ospf_ospf_ip:
       state: present
       ip_addr: 10.0.0.1
       dead_interval: 1
@@ -33,15 +27,12 @@
       retransmit_interval: 1
       transmit_delay: 1
 
-- name: Delete a10_interface_lif_ip_ospf_ospf_ip example playbook
+- name: Delete a10.acos_axapi.a10_interface_lif_ip_ospf_ospf_ip example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_interface_lif_ip_ospf_ospf_ip instance
-    a10_interface_lif_ip_ospf_ospf_ip:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_interface_lif_ip_ospf_ospf_ip instance
+    a10.acos_axapi.a10_interface_lif_ip_ospf_ospf_ip:
       state: absent
       ip_addr: 10.0.0.1
       dead_interval: 1

--- a/examples/single_task/interface/a10_interface_loopback.yaml
+++ b/examples/single_task/interface/a10_interface_loopback.yaml
@@ -1,36 +1,27 @@
 
 
-- name: Create a10_interface_loopback example playbook
+- name: Create a10.acos_axapi.a10_interface_loopback example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_interface_loopback instance
-    a10_interface_loopback:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_interface_loopback instance
+    a10.acos_axapi.a10_interface_loopback:
       ifnum: 0
 
-- name: Update a10_interface_loopback example playbook
+- name: Update a10.acos_axapi.a10_interface_loopback example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_interface_loopback instance
-    a10_interface_loopback:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_interface_loopback instance
+    a10.acos_axapi.a10_interface_loopback:
       state: present
       ifnum: 0
 
-- name: Delete a10_interface_loopback example playbook
+- name: Delete a10.acos_axapi.a10_interface_loopback example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_interface_loopback instance
-    a10_interface_loopback:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_interface_loopback instance
+    a10.acos_axapi.a10_interface_loopback:
       state: absent
       ifnum: 0

--- a/examples/single_task/interface/a10_interface_loopback_ip_ospf_ospf_ip.yaml
+++ b/examples/single_task/interface/a10_interface_loopback_ip_ospf_ospf_ip.yaml
@@ -1,14 +1,11 @@
 
 
-- name: Create a10_interface_loopback_ip_ospf_ospf_ip example playbook
+- name: Create a10.acos_axapi.a10_interface_loopback_ip_ospf_ospf_ip example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_interface_loopback_ip_ospf_ospf_ip instance
-    a10_interface_loopback_ip_ospf_ospf_ip:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_interface_loopback_ip_ospf_ospf_ip instance
+    a10.acos_axapi.a10_interface_loopback_ip_ospf_ospf_ip:
       ip_addr: 10.0.0.1
       dead_interval: 1
       hello_interval: 1
@@ -16,15 +13,12 @@
       retransmit_interval: 1
       transmit_delay: 1
 
-- name: Update a10_interface_loopback_ip_ospf_ospf_ip example playbook
+- name: Update a10.acos_axapi.a10_interface_loopback_ip_ospf_ospf_ip example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_interface_loopback_ip_ospf_ospf_ip instance
-    a10_interface_loopback_ip_ospf_ospf_ip:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_interface_loopback_ip_ospf_ospf_ip instance
+    a10.acos_axapi.a10_interface_loopback_ip_ospf_ospf_ip:
       state: present
       ip_addr: 10.0.0.1
       dead_interval: 1
@@ -33,15 +27,12 @@
       retransmit_interval: 1
       transmit_delay: 1
 
-- name: Delete a10_interface_loopback_ip_ospf_ospf_ip example playbook
+- name: Delete a10.acos_axapi.a10_interface_loopback_ip_ospf_ospf_ip example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_interface_loopback_ip_ospf_ospf_ip instance
-    a10_interface_loopback_ip_ospf_ospf_ip:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_interface_loopback_ip_ospf_ospf_ip instance
+    a10.acos_axapi.a10_interface_loopback_ip_ospf_ospf_ip:
       state: absent
       ip_addr: 10.0.0.1
       dead_interval: 1

--- a/examples/single_task/interface/a10_interface_trunk.yaml
+++ b/examples/single_task/interface/a10_interface_trunk.yaml
@@ -1,41 +1,32 @@
 
 
-- name: Create a10_interface_trunk example playbook
+- name: Create a10.acos_axapi.a10_interface_trunk example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_interface_trunk instance
-    a10_interface_trunk:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_interface_trunk instance
+    a10.acos_axapi.a10_interface_trunk:
       ifnum: 1
       timer: 1
       action: enable
 
-- name: Update a10_interface_trunk example playbook
+- name: Update a10.acos_axapi.a10_interface_trunk example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_interface_trunk instance
-    a10_interface_trunk:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_interface_trunk instance
+    a10.acos_axapi.a10_interface_trunk:
       state: present
       ifnum: 1
       timer: 1
       action: enable
 
-- name: Delete a10_interface_trunk example playbook
+- name: Delete a10.acos_axapi.a10_interface_trunk example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_interface_trunk instance
-    a10_interface_trunk:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_interface_trunk instance
+    a10.acos_axapi.a10_interface_trunk:
       state: absent
       ifnum: 1
       timer: 1

--- a/examples/single_task/interface/a10_interface_trunk_ip_ospf_ospf_ip.yaml
+++ b/examples/single_task/interface/a10_interface_trunk_ip_ospf_ospf_ip.yaml
@@ -1,14 +1,11 @@
 
 
-- name: Create a10_interface_trunk_ip_ospf_ospf_ip example playbook
+- name: Create a10.acos_axapi.a10_interface_trunk_ip_ospf_ospf_ip example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_interface_trunk_ip_ospf_ospf_ip instance
-    a10_interface_trunk_ip_ospf_ospf_ip:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_interface_trunk_ip_ospf_ospf_ip instance
+    a10.acos_axapi.a10_interface_trunk_ip_ospf_ospf_ip:
       ip_addr: 10.0.0.1
       dead_interval: 1
       hello_interval: 1
@@ -16,15 +13,12 @@
       retransmit_interval: 1
       transmit_delay: 1
 
-- name: Update a10_interface_trunk_ip_ospf_ospf_ip example playbook
+- name: Update a10.acos_axapi.a10_interface_trunk_ip_ospf_ospf_ip example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_interface_trunk_ip_ospf_ospf_ip instance
-    a10_interface_trunk_ip_ospf_ospf_ip:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_interface_trunk_ip_ospf_ospf_ip instance
+    a10.acos_axapi.a10_interface_trunk_ip_ospf_ospf_ip:
       state: present
       ip_addr: 10.0.0.1
       dead_interval: 1
@@ -33,15 +27,12 @@
       retransmit_interval: 1
       transmit_delay: 1
 
-- name: Delete a10_interface_trunk_ip_ospf_ospf_ip example playbook
+- name: Delete a10.acos_axapi.a10_interface_trunk_ip_ospf_ospf_ip example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_interface_trunk_ip_ospf_ospf_ip instance
-    a10_interface_trunk_ip_ospf_ospf_ip:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_interface_trunk_ip_ospf_ospf_ip instance
+    a10.acos_axapi.a10_interface_trunk_ip_ospf_ospf_ip:
       state: absent
       ip_addr: 10.0.0.1
       dead_interval: 1

--- a/examples/single_task/interface/a10_interface_trunk_nptv6_domain.yaml
+++ b/examples/single_task/interface/a10_interface_trunk_nptv6_domain.yaml
@@ -1,39 +1,30 @@
 
 
-- name: Create a10_interface_trunk_nptv6_domain example playbook
+- name: Create a10.acos_axapi.a10_interface_trunk_nptv6_domain example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_interface_trunk_nptv6_domain instance
-    a10_interface_trunk_nptv6_domain:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_interface_trunk_nptv6_domain instance
+    a10.acos_axapi.a10_interface_trunk_nptv6_domain:
       domain_name: NO_EXAMPLE
       bind_type: inside
 
-- name: Update a10_interface_trunk_nptv6_domain example playbook
+- name: Update a10.acos_axapi.a10_interface_trunk_nptv6_domain example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_interface_trunk_nptv6_domain instance
-    a10_interface_trunk_nptv6_domain:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_interface_trunk_nptv6_domain instance
+    a10.acos_axapi.a10_interface_trunk_nptv6_domain:
       state: present
       domain_name: NO_EXAMPLE
       bind_type: inside
 
-- name: Delete a10_interface_trunk_nptv6_domain example playbook
+- name: Delete a10.acos_axapi.a10_interface_trunk_nptv6_domain example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_interface_trunk_nptv6_domain instance
-    a10_interface_trunk_nptv6_domain:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_interface_trunk_nptv6_domain instance
+    a10.acos_axapi.a10_interface_trunk_nptv6_domain:
       state: absent
       domain_name: NO_EXAMPLE
       bind_type: inside

--- a/examples/single_task/interface/a10_interface_tunnel.yaml
+++ b/examples/single_task/interface/a10_interface_tunnel.yaml
@@ -1,43 +1,34 @@
 
 
-- name: Create a10_interface_tunnel example playbook
+- name: Create a10.acos_axapi.a10_interface_tunnel example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_interface_tunnel instance
-    a10_interface_tunnel:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_interface_tunnel instance
+    a10.acos_axapi.a10_interface_tunnel:
       ifnum: 1
       action: enable
       speed: 1
       load_interval: 5
 
-- name: Update a10_interface_tunnel example playbook
+- name: Update a10.acos_axapi.a10_interface_tunnel example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_interface_tunnel instance
-    a10_interface_tunnel:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_interface_tunnel instance
+    a10.acos_axapi.a10_interface_tunnel:
       state: present
       ifnum: 1
       action: enable
       speed: 1
       load_interval: 5
 
-- name: Delete a10_interface_tunnel example playbook
+- name: Delete a10.acos_axapi.a10_interface_tunnel example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_interface_tunnel instance
-    a10_interface_tunnel:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_interface_tunnel instance
+    a10.acos_axapi.a10_interface_tunnel:
       state: absent
       ifnum: 1
       action: enable

--- a/examples/single_task/interface/a10_interface_tunnel_ip_ospf_ospf_ip.yaml
+++ b/examples/single_task/interface/a10_interface_tunnel_ip_ospf_ospf_ip.yaml
@@ -1,14 +1,11 @@
 
 
-- name: Create a10_interface_tunnel_ip_ospf_ospf_ip example playbook
+- name: Create a10.acos_axapi.a10_interface_tunnel_ip_ospf_ospf_ip example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_interface_tunnel_ip_ospf_ospf_ip instance
-    a10_interface_tunnel_ip_ospf_ospf_ip:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_interface_tunnel_ip_ospf_ospf_ip instance
+    a10.acos_axapi.a10_interface_tunnel_ip_ospf_ospf_ip:
       ip_addr: 10.0.0.1
       dead_interval: 1
       hello_interval: 1
@@ -16,15 +13,12 @@
       retransmit_interval: 1
       transmit_delay: 1
 
-- name: Update a10_interface_tunnel_ip_ospf_ospf_ip example playbook
+- name: Update a10.acos_axapi.a10_interface_tunnel_ip_ospf_ospf_ip example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_interface_tunnel_ip_ospf_ospf_ip instance
-    a10_interface_tunnel_ip_ospf_ospf_ip:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_interface_tunnel_ip_ospf_ospf_ip instance
+    a10.acos_axapi.a10_interface_tunnel_ip_ospf_ospf_ip:
       state: present
       ip_addr: 10.0.0.1
       dead_interval: 1
@@ -33,15 +27,12 @@
       retransmit_interval: 1
       transmit_delay: 1
 
-- name: Delete a10_interface_tunnel_ip_ospf_ospf_ip example playbook
+- name: Delete a10.acos_axapi.a10_interface_tunnel_ip_ospf_ospf_ip example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_interface_tunnel_ip_ospf_ospf_ip instance
-    a10_interface_tunnel_ip_ospf_ospf_ip:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_interface_tunnel_ip_ospf_ospf_ip instance
+    a10.acos_axapi.a10_interface_tunnel_ip_ospf_ospf_ip:
       state: absent
       ip_addr: 10.0.0.1
       dead_interval: 1

--- a/examples/single_task/interface/a10_interface_ve.yaml
+++ b/examples/single_task/interface/a10_interface_ve.yaml
@@ -1,39 +1,30 @@
 
 
-- name: Create a10_interface_ve example playbook
+- name: Create a10.acos_axapi.a10_interface_ve example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_interface_ve instance
-    a10_interface_ve:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_interface_ve instance
+    a10.acos_axapi.a10_interface_ve:
       ifnum: 2
       action: enable
 
-- name: Update a10_interface_ve example playbook
+- name: Update a10.acos_axapi.a10_interface_ve example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_interface_ve instance
-    a10_interface_ve:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_interface_ve instance
+    a10.acos_axapi.a10_interface_ve:
       state: present
       ifnum: 2
       action: enable
 
-- name: Delete a10_interface_ve example playbook
+- name: Delete a10.acos_axapi.a10_interface_ve example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_interface_ve instance
-    a10_interface_ve:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_interface_ve instance
+    a10.acos_axapi.a10_interface_ve:
       state: absent
       ifnum: 2
       action: enable

--- a/examples/single_task/interface/a10_interface_ve_ip_ospf_ospf_ip.yaml
+++ b/examples/single_task/interface/a10_interface_ve_ip_ospf_ospf_ip.yaml
@@ -1,14 +1,11 @@
 
 
-- name: Create a10_interface_ve_ip_ospf_ospf_ip example playbook
+- name: Create a10.acos_axapi.a10_interface_ve_ip_ospf_ospf_ip example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_interface_ve_ip_ospf_ospf_ip instance
-    a10_interface_ve_ip_ospf_ospf_ip:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_interface_ve_ip_ospf_ospf_ip instance
+    a10.acos_axapi.a10_interface_ve_ip_ospf_ospf_ip:
       ip_addr: 10.0.0.1
       dead_interval: 1
       hello_interval: 1
@@ -16,15 +13,12 @@
       retransmit_interval: 1
       transmit_delay: 1
 
-- name: Update a10_interface_ve_ip_ospf_ospf_ip example playbook
+- name: Update a10.acos_axapi.a10_interface_ve_ip_ospf_ospf_ip example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_interface_ve_ip_ospf_ospf_ip instance
-    a10_interface_ve_ip_ospf_ospf_ip:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_interface_ve_ip_ospf_ospf_ip instance
+    a10.acos_axapi.a10_interface_ve_ip_ospf_ospf_ip:
       state: present
       ip_addr: 10.0.0.1
       dead_interval: 1
@@ -33,15 +27,12 @@
       retransmit_interval: 1
       transmit_delay: 1
 
-- name: Delete a10_interface_ve_ip_ospf_ospf_ip example playbook
+- name: Delete a10.acos_axapi.a10_interface_ve_ip_ospf_ospf_ip example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_interface_ve_ip_ospf_ospf_ip instance
-    a10_interface_ve_ip_ospf_ospf_ip:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_interface_ve_ip_ospf_ospf_ip instance
+    a10.acos_axapi.a10_interface_ve_ip_ospf_ospf_ip:
       state: absent
       ip_addr: 10.0.0.1
       dead_interval: 1

--- a/examples/single_task/interface/a10_interface_ve_nptv6_domain.yaml
+++ b/examples/single_task/interface/a10_interface_ve_nptv6_domain.yaml
@@ -1,39 +1,30 @@
 
 
-- name: Create a10_interface_ve_nptv6_domain example playbook
+- name: Create a10.acos_axapi.a10_interface_ve_nptv6_domain example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_interface_ve_nptv6_domain instance
-    a10_interface_ve_nptv6_domain:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_interface_ve_nptv6_domain instance
+    a10.acos_axapi.a10_interface_ve_nptv6_domain:
       domain_name: NO_EXAMPLE
       bind_type: inside
 
-- name: Update a10_interface_ve_nptv6_domain example playbook
+- name: Update a10.acos_axapi.a10_interface_ve_nptv6_domain example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_interface_ve_nptv6_domain instance
-    a10_interface_ve_nptv6_domain:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_interface_ve_nptv6_domain instance
+    a10.acos_axapi.a10_interface_ve_nptv6_domain:
       state: present
       domain_name: NO_EXAMPLE
       bind_type: inside
 
-- name: Delete a10_interface_ve_nptv6_domain example playbook
+- name: Delete a10.acos_axapi.a10_interface_ve_nptv6_domain example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_interface_ve_nptv6_domain instance
-    a10_interface_ve_nptv6_domain:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_interface_ve_nptv6_domain instance
+    a10.acos_axapi.a10_interface_ve_nptv6_domain:
       state: absent
       domain_name: NO_EXAMPLE
       bind_type: inside

--- a/examples/single_task/ip/dns.yaml
+++ b/examples/single_task/ip/dns.yaml
@@ -1,13 +1,8 @@
 - name: DNS
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: a10_ip_dns_primary
-    a10_ip_dns_primary:
+  - name: a10.acos_axapi.a10_ip_dns_primary
+    a10.acos_axapi.a10_ip_dns_primary:
       state: "present"
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
       ip_v4_addr: "8.8.8.8"

--- a/examples/single_task/network/a10_network_arp_static.yaml
+++ b/examples/single_task/network/a10_network_arp_static.yaml
@@ -1,39 +1,30 @@
 
 
-- name: Create a10_network_arp_static example playbook
+- name: Create a10.acos_axapi.a10_network_arp_static example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_network_arp_static instance
-    a10_network_arp_static:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_network_arp_static instance
+    a10.acos_axapi.a10_network_arp_static:
       ip_addr: 10.0.0.1
       vlan: 2
 
-- name: Update a10_network_arp_static example playbook
+- name: Update a10.acos_axapi.a10_network_arp_static example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_network_arp_static instance
-    a10_network_arp_static:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_network_arp_static instance
+    a10.acos_axapi.a10_network_arp_static:
       state: present
       ip_addr: 10.0.0.1
       vlan: 2
 
-- name: Delete a10_network_arp_static example playbook
+- name: Delete a10.acos_axapi.a10_network_arp_static example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_network_arp_static instance
-    a10_network_arp_static:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_network_arp_static instance
+    a10.acos_axapi.a10_network_arp_static:
       state: absent
       ip_addr: 10.0.0.1
       vlan: 2

--- a/examples/single_task/network/a10_network_bpdu_fwd_group.yaml
+++ b/examples/single_task/network/a10_network_bpdu_fwd_group.yaml
@@ -1,36 +1,27 @@
 
 
-- name: Create a10_network_bpdu_fwd_group example playbook
+- name: Create a10.acos_axapi.a10_network_bpdu_fwd_group example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_network_bpdu_fwd_group instance
-    a10_network_bpdu_fwd_group:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_network_bpdu_fwd_group instance
+    a10.acos_axapi.a10_network_bpdu_fwd_group:
       bpdu_fwd_group_number: 1
 
-- name: Update a10_network_bpdu_fwd_group example playbook
+- name: Update a10.acos_axapi.a10_network_bpdu_fwd_group example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_network_bpdu_fwd_group instance
-    a10_network_bpdu_fwd_group:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_network_bpdu_fwd_group instance
+    a10.acos_axapi.a10_network_bpdu_fwd_group:
       state: present
       bpdu_fwd_group_number: 1
 
-- name: Delete a10_network_bpdu_fwd_group example playbook
+- name: Delete a10.acos_axapi.a10_network_bpdu_fwd_group example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_network_bpdu_fwd_group instance
-    a10_network_bpdu_fwd_group:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_network_bpdu_fwd_group instance
+    a10.acos_axapi.a10_network_bpdu_fwd_group:
       state: absent
       bpdu_fwd_group_number: 1

--- a/examples/single_task/network/a10_network_bridge_vlan_group.yaml
+++ b/examples/single_task/network/a10_network_bridge_vlan_group.yaml
@@ -1,39 +1,30 @@
 
 
-- name: Create a10_network_bridge_vlan_group example playbook
+- name: Create a10.acos_axapi.a10_network_bridge_vlan_group example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_network_bridge_vlan_group instance
-    a10_network_bridge_vlan_group:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_network_bridge_vlan_group instance
+    a10.acos_axapi.a10_network_bridge_vlan_group:
       bridge_vlan_group_number: 1
       forward_traffic: forward-ip-traffic
 
-- name: Update a10_network_bridge_vlan_group example playbook
+- name: Update a10.acos_axapi.a10_network_bridge_vlan_group example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_network_bridge_vlan_group instance
-    a10_network_bridge_vlan_group:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_network_bridge_vlan_group instance
+    a10.acos_axapi.a10_network_bridge_vlan_group:
       state: present
       bridge_vlan_group_number: 1
       forward_traffic: forward-ip-traffic
 
-- name: Delete a10_network_bridge_vlan_group example playbook
+- name: Delete a10.acos_axapi.a10_network_bridge_vlan_group example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_network_bridge_vlan_group instance
-    a10_network_bridge_vlan_group:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_network_bridge_vlan_group instance
+    a10.acos_axapi.a10_network_bridge_vlan_group:
       state: absent
       bridge_vlan_group_number: 1
       forward_traffic: forward-ip-traffic

--- a/examples/single_task/network/a10_network_lacp_passthrough.yaml
+++ b/examples/single_task/network/a10_network_lacp_passthrough.yaml
@@ -1,39 +1,30 @@
 
 
-- name: Create a10_network_lacp_passthrough example playbook
+- name: Create a10.acos_axapi.a10_network_lacp_passthrough example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_network_lacp_passthrough instance
-    a10_network_lacp_passthrough:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_network_lacp_passthrough instance
+    a10.acos_axapi.a10_network_lacp_passthrough:
       peer_from: None
       peer_to: None
 
-- name: Update a10_network_lacp_passthrough example playbook
+- name: Update a10.acos_axapi.a10_network_lacp_passthrough example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_network_lacp_passthrough instance
-    a10_network_lacp_passthrough:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_network_lacp_passthrough instance
+    a10.acos_axapi.a10_network_lacp_passthrough:
       state: present
       peer_from: None
       peer_to: None
 
-- name: Delete a10_network_lacp_passthrough example playbook
+- name: Delete a10.acos_axapi.a10_network_lacp_passthrough example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_network_lacp_passthrough instance
-    a10_network_lacp_passthrough:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_network_lacp_passthrough instance
+    a10.acos_axapi.a10_network_lacp_passthrough:
       state: absent
       peer_from: None
       peer_to: None

--- a/examples/single_task/network/a10_network_lldp_management_address_dns.yaml
+++ b/examples/single_task/network/a10_network_lldp_management_address_dns.yaml
@@ -1,36 +1,27 @@
 
 
-- name: Create a10_network_lldp_management_address_dns example playbook
+- name: Create a10.acos_axapi.a10_network_lldp_management_address_dns example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_network_lldp_management_address_dns instance
-    a10_network_lldp_management_address_dns:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_network_lldp_management_address_dns instance
+    a10.acos_axapi.a10_network_lldp_management_address_dns:
       dns: NO_EXAMPLE
 
-- name: Update a10_network_lldp_management_address_dns example playbook
+- name: Update a10.acos_axapi.a10_network_lldp_management_address_dns example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_network_lldp_management_address_dns instance
-    a10_network_lldp_management_address_dns:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_network_lldp_management_address_dns instance
+    a10.acos_axapi.a10_network_lldp_management_address_dns:
       state: present
       dns: NO_EXAMPLE
 
-- name: Delete a10_network_lldp_management_address_dns example playbook
+- name: Delete a10.acos_axapi.a10_network_lldp_management_address_dns example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_network_lldp_management_address_dns instance
-    a10_network_lldp_management_address_dns:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_network_lldp_management_address_dns instance
+    a10.acos_axapi.a10_network_lldp_management_address_dns:
       state: absent
       dns: NO_EXAMPLE

--- a/examples/single_task/network/a10_network_lldp_management_address_ipv4_addr.yaml
+++ b/examples/single_task/network/a10_network_lldp_management_address_ipv4_addr.yaml
@@ -1,36 +1,27 @@
 
 
-- name: Create a10_network_lldp_management_address_ipv4_addr example playbook
+- name: Create a10.acos_axapi.a10_network_lldp_management_address_ipv4_addr example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_network_lldp_management_address_ipv4_addr instance
-    a10_network_lldp_management_address_ipv4_addr:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_network_lldp_management_address_ipv4_addr instance
+    a10.acos_axapi.a10_network_lldp_management_address_ipv4_addr:
       ipv4: 10.0.0.1
 
-- name: Update a10_network_lldp_management_address_ipv4_addr example playbook
+- name: Update a10.acos_axapi.a10_network_lldp_management_address_ipv4_addr example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_network_lldp_management_address_ipv4_addr instance
-    a10_network_lldp_management_address_ipv4_addr:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_network_lldp_management_address_ipv4_addr instance
+    a10.acos_axapi.a10_network_lldp_management_address_ipv4_addr:
       state: present
       ipv4: 10.0.0.1
 
-- name: Delete a10_network_lldp_management_address_ipv4_addr example playbook
+- name: Delete a10.acos_axapi.a10_network_lldp_management_address_ipv4_addr example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_network_lldp_management_address_ipv4_addr instance
-    a10_network_lldp_management_address_ipv4_addr:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_network_lldp_management_address_ipv4_addr instance
+    a10.acos_axapi.a10_network_lldp_management_address_ipv4_addr:
       state: absent
       ipv4: 10.0.0.1

--- a/examples/single_task/network/a10_network_lldp_management_address_ipv6_addr.yaml
+++ b/examples/single_task/network/a10_network_lldp_management_address_ipv6_addr.yaml
@@ -1,36 +1,27 @@
 
 
-- name: Create a10_network_lldp_management_address_ipv6_addr example playbook
+- name: Create a10.acos_axapi.a10_network_lldp_management_address_ipv6_addr example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_network_lldp_management_address_ipv6_addr instance
-    a10_network_lldp_management_address_ipv6_addr:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_network_lldp_management_address_ipv6_addr instance
+    a10.acos_axapi.a10_network_lldp_management_address_ipv6_addr:
       ipv6: NO_EXAMPLE
 
-- name: Update a10_network_lldp_management_address_ipv6_addr example playbook
+- name: Update a10.acos_axapi.a10_network_lldp_management_address_ipv6_addr example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_network_lldp_management_address_ipv6_addr instance
-    a10_network_lldp_management_address_ipv6_addr:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_network_lldp_management_address_ipv6_addr instance
+    a10.acos_axapi.a10_network_lldp_management_address_ipv6_addr:
       state: present
       ipv6: NO_EXAMPLE
 
-- name: Delete a10_network_lldp_management_address_ipv6_addr example playbook
+- name: Delete a10.acos_axapi.a10_network_lldp_management_address_ipv6_addr example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_network_lldp_management_address_ipv6_addr instance
-    a10_network_lldp_management_address_ipv6_addr:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_network_lldp_management_address_ipv6_addr instance
+    a10.acos_axapi.a10_network_lldp_management_address_ipv6_addr:
       state: absent
       ipv6: NO_EXAMPLE

--- a/examples/single_task/network/a10_network_mac_address_static.yaml
+++ b/examples/single_task/network/a10_network_mac_address_static.yaml
@@ -1,39 +1,30 @@
 
 
-- name: Create a10_network_mac_address_static example playbook
+- name: Create a10.acos_axapi.a10_network_mac_address_static example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_network_mac_address_static instance
-    a10_network_mac_address_static:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_network_mac_address_static instance
+    a10.acos_axapi.a10_network_mac_address_static:
       mac: NO_EXAMPLE
       vlan: 2
 
-- name: Update a10_network_mac_address_static example playbook
+- name: Update a10.acos_axapi.a10_network_mac_address_static example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_network_mac_address_static instance
-    a10_network_mac_address_static:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_network_mac_address_static instance
+    a10.acos_axapi.a10_network_mac_address_static:
       state: present
       mac: NO_EXAMPLE
       vlan: 2
 
-- name: Delete a10_network_mac_address_static example playbook
+- name: Delete a10.acos_axapi.a10_network_mac_address_static example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_network_mac_address_static instance
-    a10_network_mac_address_static:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_network_mac_address_static instance
+    a10.acos_axapi.a10_network_mac_address_static:
       state: absent
       mac: NO_EXAMPLE
       vlan: 2

--- a/examples/single_task/network/a10_network_vlan.yaml
+++ b/examples/single_task/network/a10_network_vlan.yaml
@@ -1,36 +1,27 @@
 
 
-- name: Create a10_network_vlan example playbook
+- name: Create a10.acos_axapi.a10_network_vlan example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_network_vlan instance
-    a10_network_vlan:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_network_vlan instance
+    a10.acos_axapi.a10_network_vlan:
       vlan_num: 2
 
-- name: Update a10_network_vlan example playbook
+- name: Update a10.acos_axapi.a10_network_vlan example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_network_vlan instance
-    a10_network_vlan:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_network_vlan instance
+    a10.acos_axapi.a10_network_vlan:
       state: present
       vlan_num: 2
 
-- name: Delete a10_network_vlan example playbook
+- name: Delete a10.acos_axapi.a10_network_vlan example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_network_vlan instance
-    a10_network_vlan:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_network_vlan instance
+    a10.acos_axapi.a10_network_vlan:
       state: absent
       vlan_num: 2

--- a/examples/single_task/rba/group/a10_rba_group_create.yaml
+++ b/examples/single_task/rba/group/a10_rba_group_create.yaml
@@ -1,15 +1,10 @@
 ---
 - name: Create rba group and add user to this group
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
     - name: Create rba group and add user to this group
-      a10_rba_group:
-        a10_host: "{{ a10_host }}"
-        a10_username: "{{ a10_username }}"
-        a10_password: "{{ a10_password }}"
-        a10_protocol: "{{ a10_protocol }}"
-        a10_port: "{{ a10_port }}"
+      a10.acos_axapi.a10_rba_group:
         user_list:
           - user: "user01" #Enter existing user
         name: "rba_group_01" #name of rba group

--- a/examples/single_task/rba/group/a10_rba_group_delete.yaml
+++ b/examples/single_task/rba/group/a10_rba_group_delete.yaml
@@ -1,13 +1,8 @@
 ---
 - name: Create rba group and add user to this group
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
     - name: Create rba group and add user to this group
-      a10_rba_group:
-        a10_host: "{{ a10_host }}"
-        a10_username: "{{ a10_username }}"
-        a10_password: "{{ a10_password }}"
-        a10_protocol: "{{ a10_protocol }}"
-        a10_port: "{{ a10_port }}"
+      a10.acos_axapi.a10_rba_group:
         state: "absent"

--- a/examples/single_task/rba/group/a10_rba_group_update.yaml
+++ b/examples/single_task/rba/group/a10_rba_group_update.yaml
@@ -1,15 +1,10 @@
 ---
 - name: Create rba group and add user to this group
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
     - name: Create rba group and add user to this group
-      a10_rba_group:
-        a10_host: "{{ a10_host }}"
-        a10_username: "{{ a10_username }}"
-        a10_password: "{{ a10_password }}"
-        a10_protocol: "{{ a10_protocol }}"
-        a10_port: "{{ a10_port }}"
+      a10.acos_axapi.a10_rba_group:
         state: "present"
         user_list:
           - user: "user01" #Enter existing user

--- a/examples/single_task/rba/role/a10_rba_role_create.yaml
+++ b/examples/single_task/rba/role/a10_rba_role_create.yaml
@@ -1,15 +1,10 @@
 ---
 - name: RBA role
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
     - name: Create RBA role
-      a10_rba_role:
-        a10_host: "{{ a10_host }}"
-        a10_username: "{{ a10_username }}"
-        a10_password: "{{ a10_password }}"
-        a10_port: "{{ a10_port }}"
-        a10_protocol: "{{ a10_protocol }}"
+      a10.acos_axapi.a10_rba_role:
         name: "role01" #name of RBA role
         rule_list:
         - operation: no-access

--- a/examples/single_task/rba/role/a10_rba_role_delete.yaml
+++ b/examples/single_task/rba/role/a10_rba_role_delete.yaml
@@ -1,14 +1,9 @@
 ---
 - name: RBA role
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
     - name: Create RBA role
-      a10_rba_role:
-        a10_host: "{{ a10_host }}"
-        a10_username: "{{ a10_username }}"
-        a10_password: "{{ a10_password }}"
-        a10_port: "{{ a10_port }}"
-        a10_protocol: "{{ a10_protocol }}"
+      a10.acos_axapi.a10_rba_role:
         name: "role01" #name of RBA role
         state: "absent"

--- a/examples/single_task/rba/role/a10_rba_role_update.yaml
+++ b/examples/single_task/rba/role/a10_rba_role_update.yaml
@@ -1,15 +1,10 @@
 ---
 - name: RBA role
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
     - name: Create RBA role
-      a10_rba_role:
-        a10_host: "{{ a10_host }}"
-        a10_username: "{{ a10_username }}"
-        a10_password: "{{ a10_password }}"
-        a10_port: "{{ a10_port }}"
-        a10_protocol: "{{ a10_protocol }}"
+      a10.acos_axapi.a10_rba_role:
         name: "role01" #name of RBA role
         rule_list:
         - operation: no-access

--- a/examples/single_task/rba/user/a10_rba_user_create.yaml
+++ b/examples/single_task/rba/user/a10_rba_user_create.yaml
@@ -1,13 +1,8 @@
 ---
 - name: Create a10 rba user
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
     - name: a10 rba user
-      a10_rba_user:
-        a10_host: "{{ a10_host }}"
-        a10_username: "{{ a10_username }}"
-        a10_password: "{{ a10_password }}"
-        a10_protocol: "{{ a10_protocol }}"
-        a10_port: "{{ a10_port }}"
+      a10.acos_axapi.a10_rba_user:
         name: "Test" # Name of a user account

--- a/examples/single_task/rba/user/a10_rba_user_delete.yaml
+++ b/examples/single_task/rba/user/a10_rba_user_delete.yaml
@@ -1,14 +1,9 @@
 ---
 - name: Delete a10 rba user
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
     - name: a10 rba user
-      a10_rba_user:
-        a10_host: "{{ a10_host }}"
-        a10_username: "{{ a10_username }}"
-        a10_password: "{{ a10_password }}"
-        a10_protocol: "{{ a10_protocol }}"
-        a10_port: "{{ a10_port }}"
+      a10.acos_axapi.a10_rba_user:
         state: "absent"
         name: "Test" # Name of a user account

--- a/examples/single_task/rba/user/a10_rba_user_update.yaml
+++ b/examples/single_task/rba/user/a10_rba_user_update.yaml
@@ -1,14 +1,9 @@
 ---
 - name: Update a10 rba user
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   connection: local
   tasks:
     - name: a10 rba user
-      a10_rba_user:
-        a10_host: "{{ a10_host }}"
-        a10_username: "{{ a10_username }}"
-        a10_password: "{{ a10_password }}"
-        a10_protocol: "{{ a10_protocol }}"
-        a10_port: "{{ a10_port }}"
+      a10.acos_axapi.a10_rba_user:
         state: "present"
         name: "Test" # Name of a user account

--- a/examples/single_task/reload/a10_reload_all.yml
+++ b/examples/single_task/reload/a10_reload_all.yml
@@ -1,12 +1,7 @@
 - name: Reload Vthunder instance example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: a10_reload all
-    a10_reload:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_reload all
+    a10.acos_axapi.a10_reload:
       all: 1

--- a/examples/single_task/reload/a10_reload_device.yml
+++ b/examples/single_task/reload/a10_reload_device.yml
@@ -1,13 +1,8 @@
 - name: Reload Specific Device example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: a10_reload specific device
-    a10_reload:
+  - name: a10.acos_axapi.a10_reload specific device
+    a10.acos_axapi.a10_reload:
       state: "present"
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }} "
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
       device: 1

--- a/examples/single_task/show_json_config/a10_show_json_config.yaml
+++ b/examples/single_task/show_json_config/a10_show_json_config.yaml
@@ -1,11 +1,6 @@
-- hosts: all 
+- hosts: "{{desired_inventory_group}}" 
   name: "Print output of show json-config command via clideploy"
   connection: local
   tasks:
   - name: Show json config 
-    a10_show_json_config:
-      a10_host: "{{ a10_host }}" 
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+    a10.acos_axapi.a10_show_json_config:

--- a/examples/single_task/shutdown/a10_cancel_shutdown.yml
+++ b/examples/single_task/shutdown/a10_cancel_shutdown.yml
@@ -1,12 +1,7 @@
 - name: Cancel Shutdown Vthunder instance example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Cancel a10_shutdown vthunder instance
-    a10_shutdown:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Cancel a10.acos_axapi.a10_shutdown vthunder instance
+    a10.acos_axapi.a10_shutdown:
       cancel: 1

--- a/examples/single_task/shutdown/a10_shutdown.yml
+++ b/examples/single_task/shutdown/a10_shutdown.yml
@@ -1,13 +1,8 @@
 - name: Shutdown Vthunder instance example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: a10_shutdown vthunder instance
-    a10_shutdown:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_shutdown vthunder instance
+    a10.acos_axapi.a10_shutdown:
       at: 1
       time: "15.00" # Time in HH:MM format

--- a/examples/single_task/slb/server/a10_slb_server_create.yaml
+++ b/examples/single_task/slb/server/a10_slb_server_create.yaml
@@ -1,14 +1,9 @@
-- name: Create a10_slb_server example playbook
+- name: Create a10.acos_axapi.a10_slb_server example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_server instance
-    a10_slb_server:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_slb_server instance
+    a10.acos_axapi.a10_slb_server:
       name: server1
       host: 10.0.0.1
       action: enable

--- a/examples/single_task/slb/server/a10_slb_server_delete.yaml
+++ b/examples/single_task/slb/server/a10_slb_server_delete.yaml
@@ -1,14 +1,9 @@
-- name: Delete a10_slb_server example playbook
+- name: Delete a10.acos_axapi.a10_slb_server example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_server instance
-    a10_slb_server:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Delete a10.acos_axapi.a10_slb_server instance
+    a10.acos_axapi.a10_slb_server:
       state: absent
       name: server1
       host: 10.0.0.1

--- a/examples/single_task/slb/server/a10_slb_server_update.yaml
+++ b/examples/single_task/slb/server/a10_slb_server_update.yaml
@@ -1,14 +1,9 @@
-- name: Update a10_slb_server example playbook
+- name: Update a10.acos_axapi.a10_slb_server example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_server instance
-    a10_slb_server:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Update a10.acos_axapi.a10_slb_server instance
+    a10.acos_axapi.a10_slb_server:
       state: present
       name: server1
       host: 10.0.0.1

--- a/examples/single_task/slb/service_group/a10_slb_service_group_create.yaml
+++ b/examples/single_task/slb/service_group/a10_slb_service_group_create.yaml
@@ -1,14 +1,9 @@
-- name: Create a10_slb_service_group example playbook
+- name: Create a10.acos_axapi.a10_slb_service_group example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_service_group instance
-    a10_slb_service_group:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}" 
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_slb_service_group instance
+    a10.acos_axapi.a10_slb_service_group:
       protocol: tcp
       member_list:
         - host: '10.20.42.1'

--- a/examples/single_task/slb/service_group/a10_slb_service_group_delete.yaml
+++ b/examples/single_task/slb/service_group/a10_slb_service_group_delete.yaml
@@ -1,14 +1,9 @@
-- name: Delete a10_slb_service_group example playbook
+- name: Delete a10.acos_axapi.a10_slb_service_group example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_service_group instance
-    a10_slb_service_group:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Delete a10.acos_axapi.a10_slb_service_group instance
+    a10.acos_axapi.a10_slb_service_group:
       state: absent
       protocol: tcp
         - host: '10.20.42.1'

--- a/examples/single_task/slb/service_group/a10_slb_service_group_member_create.yaml
+++ b/examples/single_task/slb/service_group/a10_slb_service_group_member_create.yaml
@@ -1,14 +1,9 @@
-- name: Create a10_slb_service_group_member example playbook
+- name: Create a10.acos_axapi.a10_slb_service_group_member example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_service_group_member instance
-    a10_slb_service_group_member:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_slb_service_group_member instance
+    a10.acos_axapi.a10_slb_service_group_member:
       name: "server1"
       port: 8080
       member_state: "enable"

--- a/examples/single_task/slb/service_group/a10_slb_service_group_member_delete.yaml
+++ b/examples/single_task/slb/service_group/a10_slb_service_group_member_delete.yaml
@@ -1,14 +1,9 @@
-- name: Delete a10_slb_service_group_member example playbook
+- name: Delete a10.acos_axapi.a10_slb_service_group_member example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_service_group_member instance
-    a10_slb_service_group_member:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Delete a10.acos_axapi.a10_slb_service_group_member instance
+    a10.acos_axapi.a10_slb_service_group_member:
       state: absent
       name: server1
       port: 0

--- a/examples/single_task/slb/service_group/a10_slb_service_group_member_update.yaml
+++ b/examples/single_task/slb/service_group/a10_slb_service_group_member_update.yaml
@@ -1,14 +1,9 @@
-- name: Update a10_slb_service_group_member example playbook
+- name: Update a10.acos_axapi.a10_slb_service_group_member example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_service_group_member instance
-    a10_slb_service_group_member:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Update a10.acos_axapi.a10_slb_service_group_member instance
+    a10.acos_axapi.a10_slb_service_group_member:
       state: present
       name: server1
       port: 8080 

--- a/examples/single_task/slb/service_group/a10_slb_service_group_update.yaml
+++ b/examples/single_task/slb/service_group/a10_slb_service_group_update.yaml
@@ -1,14 +1,9 @@
-- name: Update a10_slb_service_group example playbook
+- name: Update a10.acos_axapi.a10_slb_service_group example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_service_group instance
-    a10_slb_service_group:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Update a10.acos_axapi.a10_slb_service_group instance
+    a10.acos_axapi.a10_slb_service_group:
       state: present
       protocol: tcp
       member_list:

--- a/examples/single_task/slb/service_group_member/a10_slb_service_group_member_create.yaml
+++ b/examples/single_task/slb/service_group_member/a10_slb_service_group_member_create.yaml
@@ -1,14 +1,9 @@
-- name: Create a10_slb_service_group_member example playbook
+- name: Create a10.acos_axapi.a10_slb_service_group_member example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_service_group_member instance
-    a10_slb_service_group_member:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_slb_service_group_member instance
+    a10.acos_axapi.a10_slb_service_group_member:
       name: my_member
       port: 0
       member_state: enable

--- a/examples/single_task/slb/service_group_member/a10_slb_service_group_member_delete.yaml
+++ b/examples/single_task/slb/service_group_member/a10_slb_service_group_member_delete.yaml
@@ -1,14 +1,9 @@
-- name: Delete a10_slb_service_group_member example playbook
+- name: Delete a10.acos_axapi.a10_slb_service_group_member example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_service_group_member instance
-    a10_slb_service_group_member:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Delete a10.acos_axapi.a10_slb_service_group_member instance
+    a10.acos_axapi.a10_slb_service_group_member:
       state: absent
       name: my_member
       port: 0

--- a/examples/single_task/slb/service_group_member/a10_slb_service_group_member_update.yaml
+++ b/examples/single_task/slb/service_group_member/a10_slb_service_group_member_update.yaml
@@ -1,14 +1,9 @@
-- name: Update a10_slb_service_group_member example playbook
+- name: Update a10.acos_axapi.a10_slb_service_group_member example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_service_group_member instance
-    a10_slb_service_group_member:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Update a10.acos_axapi.a10_slb_service_group_member instance
+    a10.acos_axapi.a10_slb_service_group_member:
       state: present
       name: my_member
       port: 0

--- a/examples/single_task/slb/template/a10_slb_template_cache.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_cache.yaml
@@ -1,14 +1,11 @@
 
 
-- name: Create a10_slb_template_cache example playbook
+- name: Create a10.acos_axapi.a10_slb_template_cache example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_cache instance
-    a10_slb_template_cache:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_slb_template_cache instance
+    a10.acos_axapi.a10_slb_template_cache:
       name: my_cache
       age: 1
       max_cache_size: 1
@@ -16,15 +13,12 @@
       max_content_size: 0
       replacement_policy: LFU
 
-- name: Update a10_slb_template_cache example playbook
+- name: Update a10.acos_axapi.a10_slb_template_cache example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_cache instance
-    a10_slb_template_cache:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_slb_template_cache instance
+    a10.acos_axapi.a10_slb_template_cache:
       state: present
       name: my_cache
       age: 1
@@ -33,15 +27,12 @@
       max_content_size: 0
       replacement_policy: LFU
 
-- name: Delete a10_slb_template_cache example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_cache example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_cache instance
-    a10_slb_template_cache:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_cache instance
+    a10.acos_axapi.a10_slb_template_cache:
       state: absent
       name: my_cache
       age: 1

--- a/examples/single_task/slb/template/a10_slb_template_cache_create.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_cache_create.yaml
@@ -1,14 +1,9 @@
-- name: Create a10_slb_template_cache example playbook
+- name: Create a10.acos_axapi.a10_slb_template_cache example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_cache instance
-    a10_slb_template_cache:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_slb_template_cache instance
+    a10.acos_axapi.a10_slb_template_cache:
       name: my_cache
       age: 1
       max_cache_size: 1

--- a/examples/single_task/slb/template/a10_slb_template_cache_delete.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_cache_delete.yaml
@@ -1,14 +1,9 @@
-- name: Delete a10_slb_template_cache example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_cache example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_cache instance
-    a10_slb_template_cache:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_cache instance
+    a10.acos_axapi.a10_slb_template_cache:
       state: absent
       name: my_cache
       age: 1

--- a/examples/single_task/slb/template/a10_slb_template_cache_update.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_cache_update.yaml
@@ -1,14 +1,9 @@
-- name: Update a10_slb_template_cache example playbook
+- name: Update a10.acos_axapi.a10_slb_template_cache example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_cache instance
-    a10_slb_template_cache:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Update a10.acos_axapi.a10_slb_template_cache instance
+    a10.acos_axapi.a10_slb_template_cache:
       state: present
       name: my_cache
       age: 1

--- a/examples/single_task/slb/template/a10_slb_template_cipher.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_cipher.yaml
@@ -1,36 +1,27 @@
 
 
-- name: Create a10_slb_template_cipher example playbook
+- name: Create a10.acos_axapi.a10_slb_template_cipher example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_cipher instance
-    a10_slb_template_cipher:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_slb_template_cipher instance
+    a10.acos_axapi.a10_slb_template_cipher:
       name: my_cipher
 
-- name: Update a10_slb_template_cipher example playbook
+- name: Update a10.acos_axapi.a10_slb_template_cipher example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_cipher instance
-    a10_slb_template_cipher:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_slb_template_cipher instance
+    a10.acos_axapi.a10_slb_template_cipher:
       state: present
       name: my_cipher
 
-- name: Delete a10_slb_template_cipher example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_cipher example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_cipher instance
-    a10_slb_template_cipher:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_cipher instance
+    a10.acos_axapi.a10_slb_template_cipher:
       state: absent
       name: my_cipher

--- a/examples/single_task/slb/template/a10_slb_template_cipher_create.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_cipher_create.yaml
@@ -1,12 +1,7 @@
-- name: Create a10_slb_template_cipher example playbook
+- name: Create a10.acos_axapi.a10_slb_template_cipher example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_cipher instance
-    a10_slb_template_cipher:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_slb_template_cipher instance
+    a10.acos_axapi.a10_slb_template_cipher:
       name: my_cipher

--- a/examples/single_task/slb/template/a10_slb_template_cipher_delete.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_cipher_delete.yaml
@@ -1,13 +1,8 @@
-- name: Delete a10_slb_template_cipher example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_cipher example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_cipher instance
-    a10_slb_template_cipher:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_cipher instance
+    a10.acos_axapi.a10_slb_template_cipher:
       state: absent
       name: my_cipher

--- a/examples/single_task/slb/template/a10_slb_template_cipher_update.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_cipher_update.yaml
@@ -1,13 +1,8 @@
-- name: Update a10_slb_template_cipher example playbook
+- name: Update a10.acos_axapi.a10_slb_template_cipher example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_cipher instance
-    a10_slb_template_cipher:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Update a10.acos_axapi.a10_slb_template_cipher instance
+    a10.acos_axapi.a10_slb_template_cipher:
       state: present
       name: my_cipher

--- a/examples/single_task/slb/template/a10_slb_template_client_ssl.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_client_ssl.yaml
@@ -1,14 +1,11 @@
 
 
-- name: Create a10_slb_template_client_ssl example playbook
+- name: Create a10.acos_axapi.a10_slb_template_client_ssl example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_client_ssl instance
-    a10_slb_template_client_ssl:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_slb_template_client_ssl instance
+    a10.acos_axapi.a10_slb_template_client_ssl:
       name: my_client-ssl
       ocspst_srvr_hours: 1
       ocspst_srvr_timeout: 1
@@ -28,15 +25,12 @@
       version: 30
       dgversion: 30
 
-- name: Update a10_slb_template_client_ssl example playbook
+- name: Update a10.acos_axapi.a10_slb_template_client_ssl example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_client_ssl instance
-    a10_slb_template_client_ssl:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_slb_template_client_ssl instance
+    a10.acos_axapi.a10_slb_template_client_ssl:
       state: present
       name: my_client-ssl
       ocspst_srvr_hours: 1
@@ -57,15 +51,12 @@
       version: 30
       dgversion: 30
 
-- name: Delete a10_slb_template_client_ssl example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_client_ssl example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_client_ssl instance
-    a10_slb_template_client_ssl:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_client_ssl instance
+    a10.acos_axapi.a10_slb_template_client_ssl:
       state: absent
       name: my_client-ssl
       ocspst_srvr_hours: 1

--- a/examples/single_task/slb/template/a10_slb_template_client_ssl_delete.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_client_ssl_delete.yaml
@@ -1,14 +1,9 @@
-- name: Delete a10_slb_template_client_ssl example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_client_ssl example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_client_ssl instance
-    a10_slb_template_client_ssl:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_client_ssl instance
+    a10.acos_axapi.a10_slb_template_client_ssl:
       state: absent
       name: my_client-ssl
       ocspst_srvr_hours: 1

--- a/examples/single_task/slb/template/a10_slb_template_connection_reuse.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_connection_reuse.yaml
@@ -1,43 +1,34 @@
 
 
-- name: Create a10_slb_template_connection_reuse example playbook
+- name: Create a10.acos_axapi.a10_slb_template_connection_reuse example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_connection_reuse instance
-    a10_slb_template_connection_reuse:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_slb_template_connection_reuse instance
+    a10.acos_axapi.a10_slb_template_connection_reuse:
       name: my_connection-reuse
       limit_per_server: 0
       timeout: 60
       num_conn_per_port: 1
 
-- name: Update a10_slb_template_connection_reuse example playbook
+- name: Update a10.acos_axapi.a10_slb_template_connection_reuse example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_connection_reuse instance
-    a10_slb_template_connection_reuse:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_slb_template_connection_reuse instance
+    a10.acos_axapi.a10_slb_template_connection_reuse:
       state: present
       name: my_connection-reuse
       limit_per_server: 0
       timeout: 60
       num_conn_per_port: 1
 
-- name: Delete a10_slb_template_connection_reuse example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_connection_reuse example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_connection_reuse instance
-    a10_slb_template_connection_reuse:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_connection_reuse instance
+    a10.acos_axapi.a10_slb_template_connection_reuse:
       state: absent
       name: my_connection-reuse
       limit_per_server: 0

--- a/examples/single_task/slb/template/a10_slb_template_connection_reuse_create.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_connection_reuse_create.yaml
@@ -1,14 +1,9 @@
-- name: Create a10_slb_template_connection_reuse example playbook
+- name: Create a10.acos_axapi.a10_slb_template_connection_reuse example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_connection_reuse instance
-    a10_slb_template_connection_reuse:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_slb_template_connection_reuse instance
+    a10.acos_axapi.a10_slb_template_connection_reuse:
       name: my_connection-reuse
       limit_per_server: 0
       timeout: 60

--- a/examples/single_task/slb/template/a10_slb_template_connection_reuse_delete.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_connection_reuse_delete.yaml
@@ -1,14 +1,9 @@
-- name: Delete a10_slb_template_connection_reuse example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_connection_reuse example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_connection_reuse instance
-    a10_slb_template_connection_reuse:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_connection_reuse instance
+    a10.acos_axapi.a10_slb_template_connection_reuse:
       state: absent
       name: my_connection-reuse
       limit_per_server: 0

--- a/examples/single_task/slb/template/a10_slb_template_connection_reuse_update.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_connection_reuse_update.yaml
@@ -1,14 +1,9 @@
-- name: Update a10_slb_template_connection_reuse example playbook
+- name: Update a10.acos_axapi.a10_slb_template_connection_reuse example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_connection_reuse instance
-    a10_slb_template_connection_reuse:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Update a10.acos_axapi.a10_slb_template_connection_reuse instance
+    a10.acos_axapi.a10_slb_template_connection_reuse:
       state: present
       name: my_connection-reuse
       limit_per_server: 0

--- a/examples/single_task/slb/template/a10_slb_template_dblb.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_dblb.yaml
@@ -1,36 +1,27 @@
 
 
-- name: Create a10_slb_template_dblb example playbook
+- name: Create a10.acos_axapi.a10_slb_template_dblb example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_dblb instance
-    a10_slb_template_dblb:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_slb_template_dblb instance
+    a10.acos_axapi.a10_slb_template_dblb:
       name: my_dblb
 
-- name: Update a10_slb_template_dblb example playbook
+- name: Update a10.acos_axapi.a10_slb_template_dblb example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_dblb instance
-    a10_slb_template_dblb:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_slb_template_dblb instance
+    a10.acos_axapi.a10_slb_template_dblb:
       state: present
       name: my_dblb
 
-- name: Delete a10_slb_template_dblb example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_dblb example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_dblb instance
-    a10_slb_template_dblb:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_dblb instance
+    a10.acos_axapi.a10_slb_template_dblb:
       state: absent
       name: my_dblb

--- a/examples/single_task/slb/template/a10_slb_template_dblb_create.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_dblb_create.yaml
@@ -1,12 +1,7 @@
-- name: Create a10_slb_template_dblb example playbook
+- name: Create a10.acos_axapi.a10_slb_template_dblb example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_dblb instance
-    a10_slb_template_dblb:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_slb_template_dblb instance
+    a10.acos_axapi.a10_slb_template_dblb:
       name: my_dblb

--- a/examples/single_task/slb/template/a10_slb_template_dblb_delete.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_dblb_delete.yaml
@@ -1,13 +1,8 @@
-- name: Delete a10_slb_template_dblb example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_dblb example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_dblb instance
-    a10_slb_template_dblb:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_dblb instance
+    a10.acos_axapi.a10_slb_template_dblb:
       state: absent
       name: my_dblb

--- a/examples/single_task/slb/template/a10_slb_template_dblb_update.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_dblb_update.yaml
@@ -1,13 +1,8 @@
-- name: Update a10_slb_template_dblb example playbook
+- name: Update a10.acos_axapi.a10_slb_template_dblb example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_dblb instance
-    a10_slb_template_dblb:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Update a10.acos_axapi.a10_slb_template_dblb instance
+    a10.acos_axapi.a10_slb_template_dblb:
       state: present
       name: my_dblb

--- a/examples/single_task/slb/template/a10_slb_template_diameter.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_diameter.yaml
@@ -1,29 +1,23 @@
 
 
-- name: Create a10_slb_template_diameter example playbook
+- name: Create a10.acos_axapi.a10_slb_template_diameter example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_diameter instance
-    a10_slb_template_diameter:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_slb_template_diameter instance
+    a10.acos_axapi.a10_slb_template_diameter:
       name: my_diameter
       dwr_time: 0
       idle_timeout: 1
       session_age: 1
       dwr_up_retry: 1
 
-- name: Update a10_slb_template_diameter example playbook
+- name: Update a10.acos_axapi.a10_slb_template_diameter example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_diameter instance
-    a10_slb_template_diameter:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_slb_template_diameter instance
+    a10.acos_axapi.a10_slb_template_diameter:
       state: present
       name: my_diameter
       dwr_time: 0
@@ -31,15 +25,12 @@
       session_age: 1
       dwr_up_retry: 1
 
-- name: Delete a10_slb_template_diameter example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_diameter example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_diameter instance
-    a10_slb_template_diameter:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_diameter instance
+    a10.acos_axapi.a10_slb_template_diameter:
       state: absent
       name: my_diameter
       dwr_time: 0

--- a/examples/single_task/slb/template/a10_slb_template_diameter_create.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_diameter_create.yaml
@@ -1,14 +1,9 @@
-- name: Create a10_slb_template_diameter example playbook
+- name: Create a10.acos_axapi.a10_slb_template_diameter example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_diameter instance
-    a10_slb_template_diameter:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_slb_template_diameter instance
+    a10.acos_axapi.a10_slb_template_diameter:
       name: my_diameter
       dwr_time: 0
       idle_timeout: 1

--- a/examples/single_task/slb/template/a10_slb_template_diameter_delete.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_diameter_delete.yaml
@@ -1,14 +1,9 @@
-- name: Delete a10_slb_template_diameter example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_diameter example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_diameter instance
-    a10_slb_template_diameter:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_diameter instance
+    a10.acos_axapi.a10_slb_template_diameter:
       state: absent
       name: my_diameter
       dwr_time: 0

--- a/examples/single_task/slb/template/a10_slb_template_diameter_update.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_diameter_update.yaml
@@ -1,14 +1,9 @@
-- name: Update a10_slb_template_diameter example playbook
+- name: Update a10.acos_axapi.a10_slb_template_diameter example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_diameter instance
-    a10_slb_template_diameter:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Update a10.acos_axapi.a10_slb_template_diameter instance
+    a10.acos_axapi.a10_slb_template_diameter:
       state: present
       name: my_diameter
       dwr_time: 0

--- a/examples/single_task/slb/template/a10_slb_template_dns.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_dns.yaml
@@ -1,39 +1,30 @@
 
 
-- name: Create a10_slb_template_dns example playbook
+- name: Create a10.acos_axapi.a10_slb_template_dns example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_dns instance
-    a10_slb_template_dns:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_slb_template_dns instance
+    a10.acos_axapi.a10_slb_template_dns:
       name: my_dns
       default_policy: nocache
 
-- name: Update a10_slb_template_dns example playbook
+- name: Update a10.acos_axapi.a10_slb_template_dns example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_dns instance
-    a10_slb_template_dns:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_slb_template_dns instance
+    a10.acos_axapi.a10_slb_template_dns:
       state: present
       name: my_dns
       default_policy: nocache
 
-- name: Delete a10_slb_template_dns example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_dns example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_dns instance
-    a10_slb_template_dns:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_dns instance
+    a10.acos_axapi.a10_slb_template_dns:
       state: absent
       name: my_dns
       default_policy: nocache

--- a/examples/single_task/slb/template/a10_slb_template_dns_class_list_lid.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_dns_class_list_lid.yaml
@@ -1,36 +1,27 @@
 
 
-- name: Create a10_slb_template_dns_class_list_lid example playbook
+- name: Create a10.acos_axapi.a10_slb_template_dns_class_list_lid example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_dns_class_list_lid instance
-    a10_slb_template_dns_class_list_lid:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_slb_template_dns_class_list_lid instance
+    a10.acos_axapi.a10_slb_template_dns_class_list_lid:
       lidnum: 1
 
-- name: Update a10_slb_template_dns_class_list_lid example playbook
+- name: Update a10.acos_axapi.a10_slb_template_dns_class_list_lid example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_dns_class_list_lid instance
-    a10_slb_template_dns_class_list_lid:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_slb_template_dns_class_list_lid instance
+    a10.acos_axapi.a10_slb_template_dns_class_list_lid:
       state: present
       lidnum: 1
 
-- name: Delete a10_slb_template_dns_class_list_lid example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_dns_class_list_lid example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_dns_class_list_lid instance
-    a10_slb_template_dns_class_list_lid:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_dns_class_list_lid instance
+    a10.acos_axapi.a10_slb_template_dns_class_list_lid:
       state: absent
       lidnum: 1

--- a/examples/single_task/slb/template/a10_slb_template_dns_class_list_lid_delete.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_dns_class_list_lid_delete.yaml
@@ -1,14 +1,9 @@
-- name: Delete a10_slb_template_dns_class_list_lid example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_dns_class_list_lid example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_dns_class_list_lid instance
-    a10_slb_template_dns_class_list_lid:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_dns_class_list_lid instance
+    a10.acos_axapi.a10_slb_template_dns_class_list_lid:
       state: absent
       lidnum: 1
       dns_name: "my_dns"

--- a/examples/single_task/slb/template/a10_slb_template_dns_create.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_dns_create.yaml
@@ -1,13 +1,8 @@
-- name: Create a10_slb_template_dns example playbook
+- name: Create a10.acos_axapi.a10_slb_template_dns example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_dns instance
-    a10_slb_template_dns:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_slb_template_dns instance
+    a10.acos_axapi.a10_slb_template_dns:
       name: "my_dns"
       default_policy: nocache

--- a/examples/single_task/slb/template/a10_slb_template_dns_delete.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_dns_delete.yaml
@@ -1,14 +1,9 @@
-- name: Delete a10_slb_template_dns example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_dns example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_dns instance
-    a10_slb_template_dns:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_dns instance
+    a10.acos_axapi.a10_slb_template_dns:
       state: absent
       name: my_dns
       default_policy: nocache

--- a/examples/single_task/slb/template/a10_slb_template_dns_update.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_dns_update.yaml
@@ -1,14 +1,9 @@
-- name: Update a10_slb_template_dns example playbook
+- name: Update a10.acos_axapi.a10_slb_template_dns example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_dns instance
-    a10_slb_template_dns:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Update a10.acos_axapi.a10_slb_template_dns instance
+    a10.acos_axapi.a10_slb_template_dns:
       state: present
       name: my_dns
       default_policy: nocache

--- a/examples/single_task/slb/template/a10_slb_template_dynamic_service.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_dynamic_service.yaml
@@ -1,36 +1,27 @@
 
 
-- name: Create a10_slb_template_dynamic_service example playbook
+- name: Create a10.acos_axapi.a10_slb_template_dynamic_service example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_dynamic_service instance
-    a10_slb_template_dynamic_service:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_slb_template_dynamic_service instance
+    a10.acos_axapi.a10_slb_template_dynamic_service:
       name: my_dynamic-service
 
-- name: Update a10_slb_template_dynamic_service example playbook
+- name: Update a10.acos_axapi.a10_slb_template_dynamic_service example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_dynamic_service instance
-    a10_slb_template_dynamic_service:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_slb_template_dynamic_service instance
+    a10.acos_axapi.a10_slb_template_dynamic_service:
       state: present
       name: my_dynamic-service
 
-- name: Delete a10_slb_template_dynamic_service example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_dynamic_service example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_dynamic_service instance
-    a10_slb_template_dynamic_service:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_dynamic_service instance
+    a10.acos_axapi.a10_slb_template_dynamic_service:
       state: absent
       name: my_dynamic-service

--- a/examples/single_task/slb/template/a10_slb_template_dynamic_service_create.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_dynamic_service_create.yaml
@@ -1,12 +1,7 @@
-- name: Create a10_slb_template_dynamic_service example playbook
+- name: Create a10.acos_axapi.a10_slb_template_dynamic_service example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_dynamic_service instance
-    a10_slb_template_dynamic_service:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_slb_template_dynamic_service instance
+    a10.acos_axapi.a10_slb_template_dynamic_service:
       name: my_dynamic-service

--- a/examples/single_task/slb/template/a10_slb_template_dynamic_service_delete.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_dynamic_service_delete.yaml
@@ -1,13 +1,8 @@
-- name: Delete a10_slb_template_dynamic_service example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_dynamic_service example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_dynamic_service instance
-    a10_slb_template_dynamic_service:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_dynamic_service instance
+    a10.acos_axapi.a10_slb_template_dynamic_service:
       state: absent
       name: my_dynamic-service

--- a/examples/single_task/slb/template/a10_slb_template_dynamic_service_update.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_dynamic_service_update.yaml
@@ -1,13 +1,8 @@
-- name: Update a10_slb_template_dynamic_service example playbook
+- name: Update a10.acos_axapi.a10_slb_template_dynamic_service example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_dynamic_service instance
-    a10_slb_template_dynamic_service:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Update a10.acos_axapi.a10_slb_template_dynamic_service instance
+    a10.acos_axapi.a10_slb_template_dynamic_service:
       state: present
       name: my_dynamic-service

--- a/examples/single_task/slb/template/a10_slb_template_external_service.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_external_service.yaml
@@ -1,29 +1,23 @@
 
 
-- name: Create a10_slb_template_external_service example playbook
+- name: Create a10.acos_axapi.a10_slb_template_external_service example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_external_service instance
-    a10_slb_template_external_service:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_slb_template_external_service instance
+    a10.acos_axapi.a10_slb_template_external_service:
       name: my_external-service
       failure_action: continue
       timeout: 1
       action: continue
       type: url-filter
 
-- name: Update a10_slb_template_external_service example playbook
+- name: Update a10.acos_axapi.a10_slb_template_external_service example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_external_service instance
-    a10_slb_template_external_service:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_slb_template_external_service instance
+    a10.acos_axapi.a10_slb_template_external_service:
       state: present
       name: my_external-service
       failure_action: continue
@@ -31,15 +25,12 @@
       action: continue
       type: url-filter
 
-- name: Delete a10_slb_template_external_service example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_external_service example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_external_service instance
-    a10_slb_template_external_service:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_external_service instance
+    a10.acos_axapi.a10_slb_template_external_service:
       state: absent
       name: my_external-service
       failure_action: continue

--- a/examples/single_task/slb/template/a10_slb_template_external_service_create.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_external_service_create.yaml
@@ -1,14 +1,9 @@
-- name: Create a10_slb_template_external_service example playbook
+- name: Create a10.acos_axapi.a10_slb_template_external_service example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_external_service instance
-    a10_slb_template_external_service:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_slb_template_external_service instance
+    a10.acos_axapi.a10_slb_template_external_service:
       name: my_external-service
       failure_action: continue
       timeout: 1

--- a/examples/single_task/slb/template/a10_slb_template_external_service_delete.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_external_service_delete.yaml
@@ -1,14 +1,9 @@
-- name: Delete a10_slb_template_external_service example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_external_service example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_external_service instance
-    a10_slb_template_external_service:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_external_service instance
+    a10.acos_axapi.a10_slb_template_external_service:
       state: absent
       name: my_external-service
       failure_action: continue

--- a/examples/single_task/slb/template/a10_slb_template_external_service_update.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_external_service_update.yaml
@@ -1,14 +1,9 @@
-- name: Update a10_slb_template_external_service example playbook
+- name: Update a10.acos_axapi.a10_slb_template_external_service example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_external_service instance
-    a10_slb_template_external_service:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Update a10.acos_axapi.a10_slb_template_external_service instance
+    a10.acos_axapi.a10_slb_template_external_service:
       state: present
       name: my_external-service
       failure_action: continue

--- a/examples/single_task/slb/template/a10_slb_template_fix.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_fix.yaml
@@ -1,36 +1,27 @@
 
 
-- name: Create a10_slb_template_fix example playbook
+- name: Create a10.acos_axapi.a10_slb_template_fix example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_fix instance
-    a10_slb_template_fix:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_slb_template_fix instance
+    a10.acos_axapi.a10_slb_template_fix:
       name: my_fix
 
-- name: Update a10_slb_template_fix example playbook
+- name: Update a10.acos_axapi.a10_slb_template_fix example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_fix instance
-    a10_slb_template_fix:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_slb_template_fix instance
+    a10.acos_axapi.a10_slb_template_fix:
       state: present
       name: my_fix
 
-- name: Delete a10_slb_template_fix example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_fix example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_fix instance
-    a10_slb_template_fix:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_fix instance
+    a10.acos_axapi.a10_slb_template_fix:
       state: absent
       name: my_fix

--- a/examples/single_task/slb/template/a10_slb_template_fix_create.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_fix_create.yaml
@@ -1,12 +1,7 @@
-- name: Create a10_slb_template_fix example playbook
+- name: Create a10.acos_axapi.a10_slb_template_fix example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_fix instance
-    a10_slb_template_fix:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_slb_template_fix instance
+    a10.acos_axapi.a10_slb_template_fix:
       name: my_fix

--- a/examples/single_task/slb/template/a10_slb_template_fix_delete.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_fix_delete.yaml
@@ -1,13 +1,8 @@
-- name: Delete a10_slb_template_fix example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_fix example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_fix instance
-    a10_slb_template_fix:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_fix instance
+    a10.acos_axapi.a10_slb_template_fix:
       state: absent
       name: my_fix

--- a/examples/single_task/slb/template/a10_slb_template_fix_update.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_fix_update.yaml
@@ -1,13 +1,8 @@
-- name: Update a10_slb_template_fix example playbook
+- name: Update a10.acos_axapi.a10_slb_template_fix example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_fix instance
-    a10_slb_template_fix:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Update a10.acos_axapi.a10_slb_template_fix instance
+    a10.acos_axapi.a10_slb_template_fix:
       state: present
       name: my_fix

--- a/examples/single_task/slb/template/a10_slb_template_ftp.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_ftp.yaml
@@ -1,36 +1,27 @@
 
 
-- name: Create a10_slb_template_ftp example playbook
+- name: Create a10.acos_axapi.a10_slb_template_ftp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_ftp instance
-    a10_slb_template_ftp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_slb_template_ftp instance
+    a10.acos_axapi.a10_slb_template_ftp:
       name: my_ftp
 
-- name: Update a10_slb_template_ftp example playbook
+- name: Update a10.acos_axapi.a10_slb_template_ftp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_ftp instance
-    a10_slb_template_ftp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_slb_template_ftp instance
+    a10.acos_axapi.a10_slb_template_ftp:
       state: present
       name: my_ftp
 
-- name: Delete a10_slb_template_ftp example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_ftp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_ftp instance
-    a10_slb_template_ftp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_ftp instance
+    a10.acos_axapi.a10_slb_template_ftp:
       state: absent
       name: my_ftp

--- a/examples/single_task/slb/template/a10_slb_template_ftp_create.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_ftp_create.yaml
@@ -1,12 +1,7 @@
-- name: Create a10_slb_template_ftp example playbook
+- name: Create a10.acos_axapi.a10_slb_template_ftp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_ftp instance
-    a10_slb_template_ftp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_slb_template_ftp instance
+    a10.acos_axapi.a10_slb_template_ftp:
       name: my_ftp

--- a/examples/single_task/slb/template/a10_slb_template_ftp_delete.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_ftp_delete.yaml
@@ -1,13 +1,8 @@
-- name: Delete a10_slb_template_ftp example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_ftp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_ftp instance
-    a10_slb_template_ftp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_ftp instance
+    a10.acos_axapi.a10_slb_template_ftp:
       state: absent
       name: my_ftp

--- a/examples/single_task/slb/template/a10_slb_template_ftp_update.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_ftp_update.yaml
@@ -1,13 +1,8 @@
-- name: Update a10_slb_template_ftp example playbook
+- name: Update a10.acos_axapi.a10_slb_template_ftp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_ftp instance
-    a10_slb_template_ftp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Update a10.acos_axapi.a10_slb_template_ftp instance
+    a10.acos_axapi.a10_slb_template_ftp:
       state: present
       name: my_ftp

--- a/examples/single_task/slb/template/a10_slb_template_http.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_http.yaml
@@ -1,14 +1,11 @@
 
 
-- name: Create a10_slb_template_http example playbook
+- name: Create a10.acos_axapi.a10_slb_template_http example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_http instance
-    a10_slb_template_http:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_slb_template_http instance
+    a10.acos_axapi.a10_slb_template_http:
       name: my_http
       compression_level: 1
       compression_minimum_content_length: 1
@@ -16,15 +13,12 @@
       retry_on_5xx_per_req_val: 1
       req_hdr_wait_time_val: 1
 
-- name: Update a10_slb_template_http example playbook
+- name: Update a10.acos_axapi.a10_slb_template_http example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_http instance
-    a10_slb_template_http:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_slb_template_http instance
+    a10.acos_axapi.a10_slb_template_http:
       state: present
       name: my_http
       compression_level: 1
@@ -33,15 +27,12 @@
       retry_on_5xx_per_req_val: 1
       req_hdr_wait_time_val: 1
 
-- name: Delete a10_slb_template_http example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_http example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_http instance
-    a10_slb_template_http:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_http instance
+    a10.acos_axapi.a10_slb_template_http:
       state: absent
       name: my_http
       compression_level: 1

--- a/examples/single_task/slb/template/a10_slb_template_http_create.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_http_create.yaml
@@ -1,14 +1,9 @@
-- name: Create a10_slb_template_http example playbook
+- name: Create a10.acos_axapi.a10_slb_template_http example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_http instance
-    a10_slb_template_http:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_slb_template_http instance
+    a10.acos_axapi.a10_slb_template_http:
       name: my_http
       compression_level: 1
       compression_minimum_content_length: 1

--- a/examples/single_task/slb/template/a10_slb_template_http_delete.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_http_delete.yaml
@@ -1,14 +1,9 @@
-- name: Delete a10_slb_template_http example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_http example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_http instance
-    a10_slb_template_http:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_http instance
+    a10.acos_axapi.a10_slb_template_http:
       state: absent
       name: my_http
       compression_level: 1

--- a/examples/single_task/slb/template/a10_slb_template_http_policy.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_http_policy.yaml
@@ -1,36 +1,27 @@
 
 
-- name: Create a10_slb_template_http_policy example playbook
+- name: Create a10.acos_axapi.a10_slb_template_http_policy example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_http_policy instance
-    a10_slb_template_http_policy:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_slb_template_http_policy instance
+    a10.acos_axapi.a10_slb_template_http_policy:
       name: my_http-policy
 
-- name: Update a10_slb_template_http_policy example playbook
+- name: Update a10.acos_axapi.a10_slb_template_http_policy example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_http_policy instance
-    a10_slb_template_http_policy:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_slb_template_http_policy instance
+    a10.acos_axapi.a10_slb_template_http_policy:
       state: present
       name: my_http-policy
 
-- name: Delete a10_slb_template_http_policy example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_http_policy example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_http_policy instance
-    a10_slb_template_http_policy:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_http_policy instance
+    a10.acos_axapi.a10_slb_template_http_policy:
       state: absent
       name: my_http-policy

--- a/examples/single_task/slb/template/a10_slb_template_http_policy_create.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_http_policy_create.yaml
@@ -1,12 +1,7 @@
-- name: Create a10_slb_template_http_policy example playbook
+- name: Create a10.acos_axapi.a10_slb_template_http_policy example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_http_policy instance
-    a10_slb_template_http_policy:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_slb_template_http_policy instance
+    a10.acos_axapi.a10_slb_template_http_policy:
       name: my_http-policy

--- a/examples/single_task/slb/template/a10_slb_template_http_policy_delete.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_http_policy_delete.yaml
@@ -1,13 +1,8 @@
-- name: Delete a10_slb_template_http_policy example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_http_policy example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_http_policy instance
-    a10_slb_template_http_policy:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_http_policy instance
+    a10.acos_axapi.a10_slb_template_http_policy:
       state: absent
       name: my_http-policy

--- a/examples/single_task/slb/template/a10_slb_template_http_policy_update.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_http_policy_update.yaml
@@ -1,13 +1,8 @@
-- name: Update a10_slb_template_http_policy example playbook
+- name: Update a10.acos_axapi.a10_slb_template_http_policy example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_http_policy instance
-    a10_slb_template_http_policy:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Update a10.acos_axapi.a10_slb_template_http_policy instance
+    a10.acos_axapi.a10_slb_template_http_policy:
       state: present
       name: my_http-policy

--- a/examples/single_task/slb/template/a10_slb_template_http_update.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_http_update.yaml
@@ -1,14 +1,9 @@
-- name: Update a10_slb_template_http example playbook
+- name: Update a10.acos_axapi.a10_slb_template_http example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_http instance
-    a10_slb_template_http:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Update a10.acos_axapi.a10_slb_template_http instance
+    a10.acos_axapi.a10_slb_template_http:
       state: present
       name: my_http
       compression_level: 1

--- a/examples/single_task/slb/template/a10_slb_template_imap_pop3.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_imap_pop3.yaml
@@ -1,39 +1,30 @@
 
 
-- name: Create a10_slb_template_imap_pop3 example playbook
+- name: Create a10.acos_axapi.a10_slb_template_imap_pop3 example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_imap_pop3 instance
-    a10_slb_template_imap_pop3:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_slb_template_imap_pop3 instance
+    a10.acos_axapi.a10_slb_template_imap_pop3:
       name: my_imap-pop3
       starttls: disabled
 
-- name: Update a10_slb_template_imap_pop3 example playbook
+- name: Update a10.acos_axapi.a10_slb_template_imap_pop3 example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_imap_pop3 instance
-    a10_slb_template_imap_pop3:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_slb_template_imap_pop3 instance
+    a10.acos_axapi.a10_slb_template_imap_pop3:
       state: present
       name: my_imap-pop3
       starttls: disabled
 
-- name: Delete a10_slb_template_imap_pop3 example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_imap_pop3 example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_imap_pop3 instance
-    a10_slb_template_imap_pop3:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_imap_pop3 instance
+    a10.acos_axapi.a10_slb_template_imap_pop3:
       state: absent
       name: my_imap-pop3
       starttls: disabled

--- a/examples/single_task/slb/template/a10_slb_template_imap_pop3_create.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_imap_pop3_create.yaml
@@ -1,13 +1,8 @@
-- name: Create a10_slb_template_imap_pop3 example playbook
+- name: Create a10.acos_axapi.a10_slb_template_imap_pop3 example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_imap_pop3 instance
-    a10_slb_template_imap_pop3:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_slb_template_imap_pop3 instance
+    a10.acos_axapi.a10_slb_template_imap_pop3:
       name: my_imap-pop3
       starttls: disabled

--- a/examples/single_task/slb/template/a10_slb_template_imap_pop3_delete.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_imap_pop3_delete.yaml
@@ -1,14 +1,9 @@
-- name: Delete a10_slb_template_imap_pop3 example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_imap_pop3 example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_imap_pop3 instance
-    a10_slb_template_imap_pop3:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_imap_pop3 instance
+    a10.acos_axapi.a10_slb_template_imap_pop3:
       state: absent
       name: my_imap-pop3
       starttls: disabled

--- a/examples/single_task/slb/template/a10_slb_template_imap_pop3_update.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_imap_pop3_update.yaml
@@ -1,14 +1,9 @@
-- name: Update a10_slb_template_imap_pop3 example playbook
+- name: Update a10.acos_axapi.a10_slb_template_imap_pop3 example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_imap_pop3 instance
-    a10_slb_template_imap_pop3:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Update a10.acos_axapi.a10_slb_template_imap_pop3 instance
+    a10.acos_axapi.a10_slb_template_imap_pop3:
       state: present
       name: my_imap-pop3
       starttls: disabled

--- a/examples/single_task/slb/template/a10_slb_template_logging.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_logging.yaml
@@ -1,43 +1,34 @@
 
 
-- name: Create a10_slb_template_logging example playbook
+- name: Create a10.acos_axapi.a10_slb_template_logging example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_logging instance
-    a10_slb_template_logging:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_slb_template_logging instance
+    a10.acos_axapi.a10_slb_template_logging:
       name: my_logging
       mask: X
       tcp_proxy: default
       auto: auto
 
-- name: Update a10_slb_template_logging example playbook
+- name: Update a10.acos_axapi.a10_slb_template_logging example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_logging instance
-    a10_slb_template_logging:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_slb_template_logging instance
+    a10.acos_axapi.a10_slb_template_logging:
       state: present
       name: my_logging
       mask: X
       tcp_proxy: default
       auto: auto
 
-- name: Delete a10_slb_template_logging example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_logging example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_logging instance
-    a10_slb_template_logging:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_logging instance
+    a10.acos_axapi.a10_slb_template_logging:
       state: absent
       name: my_logging
       mask: X

--- a/examples/single_task/slb/template/a10_slb_template_logging_create.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_logging_create.yaml
@@ -1,14 +1,9 @@
-- name: Create a10_slb_template_logging example playbook
+- name: Create a10.acos_axapi.a10_slb_template_logging example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_logging instance
-    a10_slb_template_logging:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_slb_template_logging instance
+    a10.acos_axapi.a10_slb_template_logging:
       name: my_logging
       tcp_proxy: default
       auto: auto

--- a/examples/single_task/slb/template/a10_slb_template_logging_delete.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_logging_delete.yaml
@@ -1,14 +1,9 @@
-- name: Delete a10_slb_template_logging example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_logging example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_logging instance
-    a10_slb_template_logging:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_logging instance
+    a10.acos_axapi.a10_slb_template_logging:
       state: absent
       name: my_logging
       tcp_proxy: default

--- a/examples/single_task/slb/template/a10_slb_template_logging_update.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_logging_update.yaml
@@ -1,14 +1,9 @@
-- name: Update a10_slb_template_logging example playbook
+- name: Update a10.acos_axapi.a10_slb_template_logging example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_logging instance
-    a10_slb_template_logging:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Update a10.acos_axapi.a10_slb_template_logging instance
+    a10.acos_axapi.a10_slb_template_logging:
       state: present
       name: my_logging
       tcp_proxy: default

--- a/examples/single_task/slb/template/a10_slb_template_monitor.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_monitor.yaml
@@ -1,39 +1,30 @@
 
 
-- name: Create a10_slb_template_monitor example playbook
+- name: Create a10.acos_axapi.a10_slb_template_monitor example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_monitor instance
-    a10_slb_template_monitor:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_slb_template_monitor instance
+    a10.acos_axapi.a10_slb_template_monitor:
       id: 1
       monitor_relation: monitor-and
 
-- name: Update a10_slb_template_monitor example playbook
+- name: Update a10.acos_axapi.a10_slb_template_monitor example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_monitor instance
-    a10_slb_template_monitor:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_slb_template_monitor instance
+    a10.acos_axapi.a10_slb_template_monitor:
       state: present
       id: 1
       monitor_relation: monitor-and
 
-- name: Delete a10_slb_template_monitor example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_monitor example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_monitor instance
-    a10_slb_template_monitor:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_monitor instance
+    a10.acos_axapi.a10_slb_template_monitor:
       state: absent
       id: 1
       monitor_relation: monitor-and

--- a/examples/single_task/slb/template/a10_slb_template_monitor_create.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_monitor_create.yaml
@@ -1,13 +1,8 @@
-- name: Create a10_slb_template_monitor example playbook
+- name: Create a10.acos_axapi.a10_slb_template_monitor example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_monitor instance
-    a10_slb_template_monitor:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_slb_template_monitor instance
+    a10.acos_axapi.a10_slb_template_monitor:
       id: 1
       monitor_relation: monitor-and

--- a/examples/single_task/slb/template/a10_slb_template_monitor_delete.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_monitor_delete.yaml
@@ -1,14 +1,9 @@
-- name: Delete a10_slb_template_monitor example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_monitor example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_monitor instance
-    a10_slb_template_monitor:
-      a10_host: 10.43.12.132
-      a10_username: admin
-      a10_password: a10
-      a10_port: 443
-      a10_protocol: https
+  - name: Delete a10.acos_axapi.a10_slb_template_monitor instance
+    a10.acos_axapi.a10_slb_template_monitor:
       state: absent
       id: 1
       monitor_relation: monitor-and

--- a/examples/single_task/slb/template/a10_slb_template_monitor_update.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_monitor_update.yaml
@@ -1,14 +1,9 @@
-- name: Update a10_slb_template_monitor example playbook
+- name: Update a10.acos_axapi.a10_slb_template_monitor example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_monitor instance
-    a10_slb_template_monitor:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Update a10.acos_axapi.a10_slb_template_monitor instance
+    a10.acos_axapi.a10_slb_template_monitor:
       state: present
       id: 1
       monitor_relation: monitor-and

--- a/examples/single_task/slb/template/a10_slb_template_persist_cookie.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_persist_cookie.yaml
@@ -1,29 +1,23 @@
 
 
-- name: Create a10_slb_template_persist_cookie example playbook
+- name: Create a10.acos_axapi.a10_slb_template_persist_cookie example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_persist_cookie instance
-    a10_slb_template_persist_cookie:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_slb_template_persist_cookie instance
+    a10.acos_axapi.a10_slb_template_persist_cookie:
       name: my_cookie
       encrypt_level: 0
       pass_phrase: ACOS4KEY
       cookie_name: sto-id
       path: /
 
-- name: Update a10_slb_template_persist_cookie example playbook
+- name: Update a10.acos_axapi.a10_slb_template_persist_cookie example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_persist_cookie instance
-    a10_slb_template_persist_cookie:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_slb_template_persist_cookie instance
+    a10.acos_axapi.a10_slb_template_persist_cookie:
       state: present
       name: my_cookie
       encrypt_level: 0
@@ -31,15 +25,12 @@
       cookie_name: sto-id
       path: /
 
-- name: Delete a10_slb_template_persist_cookie example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_persist_cookie example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_persist_cookie instance
-    a10_slb_template_persist_cookie:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_persist_cookie instance
+    a10.acos_axapi.a10_slb_template_persist_cookie:
       state: absent
       name: my_cookie
       encrypt_level: 0

--- a/examples/single_task/slb/template/a10_slb_template_persist_cookie_create.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_persist_cookie_create.yaml
@@ -1,14 +1,9 @@
-- name: Create a10_slb_template_persist_cookie example playbook
+- name: Create a10.acos_axapi.a10_slb_template_persist_cookie example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_persist_cookie instance
-    a10_slb_template_persist_cookie:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_slb_template_persist_cookie instance
+    a10.acos_axapi.a10_slb_template_persist_cookie:
       name: my_cookie
       encrypt_level: 0
       pass_phrase: ACOS4KEY

--- a/examples/single_task/slb/template/a10_slb_template_persist_cookie_delete.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_persist_cookie_delete.yaml
@@ -1,14 +1,9 @@
-- name: Delete a10_slb_template_persist_cookie example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_persist_cookie example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_persist_cookie instance
-    a10_slb_template_persist_cookie:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_persist_cookie instance
+    a10.acos_axapi.a10_slb_template_persist_cookie:
       state: absent
       name: my_cookie
       encrypt_level: 0

--- a/examples/single_task/slb/template/a10_slb_template_persist_cookie_update.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_persist_cookie_update.yaml
@@ -1,14 +1,9 @@
-- name: Update a10_slb_template_persist_cookie example playbook
+- name: Update a10.acos_axapi.a10_slb_template_persist_cookie example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_persist_cookie instance
-    a10_slb_template_persist_cookie:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Update a10.acos_axapi.a10_slb_template_persist_cookie instance
+    a10.acos_axapi.a10_slb_template_persist_cookie:
       state: present
       name: my_cookie
       encrypt_level: 0

--- a/examples/single_task/slb/template/a10_slb_template_persist_destination_ip.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_persist_destination_ip.yaml
@@ -1,43 +1,34 @@
 
 
-- name: Create a10_slb_template_persist_destination_ip example playbook
+- name: Create a10.acos_axapi.a10_slb_template_persist_destination_ip example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_persist_destination_ip instance
-    a10_slb_template_persist_destination_ip:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_slb_template_persist_destination_ip instance
+    a10.acos_axapi.a10_slb_template_persist_destination_ip:
       name: my_destination-ip
       timeout: 1
       netmask: 255.255.255.255
       netmask6: 1
 
-- name: Update a10_slb_template_persist_destination_ip example playbook
+- name: Update a10.acos_axapi.a10_slb_template_persist_destination_ip example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_persist_destination_ip instance
-    a10_slb_template_persist_destination_ip:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_slb_template_persist_destination_ip instance
+    a10.acos_axapi.a10_slb_template_persist_destination_ip:
       state: present
       name: my_destination-ip
       timeout: 1
       netmask: 255.255.255.255
       netmask6: 1
 
-- name: Delete a10_slb_template_persist_destination_ip example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_persist_destination_ip example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_persist_destination_ip instance
-    a10_slb_template_persist_destination_ip:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_persist_destination_ip instance
+    a10.acos_axapi.a10_slb_template_persist_destination_ip:
       state: absent
       name: my_destination-ip
       timeout: 1

--- a/examples/single_task/slb/template/a10_slb_template_persist_destination_ip_create.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_persist_destination_ip_create.yaml
@@ -1,14 +1,9 @@
-- name: Create a10_slb_template_persist_destination_ip example playbook
+- name: Create a10.acos_axapi.a10_slb_template_persist_destination_ip example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_persist_destination_ip instance
-    a10_slb_template_persist_destination_ip:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_slb_template_persist_destination_ip instance
+    a10.acos_axapi.a10_slb_template_persist_destination_ip:
       name: my_destination-ip
       timeout: 1
       netmask: 255.255.255.255

--- a/examples/single_task/slb/template/a10_slb_template_persist_destination_ip_delete.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_persist_destination_ip_delete.yaml
@@ -1,14 +1,9 @@
-- name: Delete a10_slb_template_persist_destination_ip example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_persist_destination_ip example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_persist_destination_ip instance
-    a10_slb_template_persist_destination_ip:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_persist_destination_ip instance
+    a10.acos_axapi.a10_slb_template_persist_destination_ip:
       state: absent
       name: my_destination-ip
       timeout: 1

--- a/examples/single_task/slb/template/a10_slb_template_persist_destination_ip_update.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_persist_destination_ip_update.yaml
@@ -1,14 +1,9 @@
-- name: Update a10_slb_template_persist_destination_ip example playbook
+- name: Update a10.acos_axapi.a10_slb_template_persist_destination_ip example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_persist_destination_ip instance
-    a10_slb_template_persist_destination_ip:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Update a10.acos_axapi.a10_slb_template_persist_destination_ip instance
+    a10.acos_axapi.a10_slb_template_persist_destination_ip:
       state: present
       name: my_destination-ip
       timeout: 1

--- a/examples/single_task/slb/template/a10_slb_template_persist_source_ip.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_persist_source_ip.yaml
@@ -1,43 +1,34 @@
 
 
-- name: Create a10_slb_template_persist_source_ip example playbook
+- name: Create a10.acos_axapi.a10_slb_template_persist_source_ip example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_persist_source_ip instance
-    a10_slb_template_persist_source_ip:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_slb_template_persist_source_ip instance
+    a10.acos_axapi.a10_slb_template_persist_source_ip:
       name: my_source-ip
       timeout: 1
       netmask: 255.255.255.255
       netmask6: 1
 
-- name: Update a10_slb_template_persist_source_ip example playbook
+- name: Update a10.acos_axapi.a10_slb_template_persist_source_ip example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_persist_source_ip instance
-    a10_slb_template_persist_source_ip:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_slb_template_persist_source_ip instance
+    a10.acos_axapi.a10_slb_template_persist_source_ip:
       state: present
       name: my_source-ip
       timeout: 1
       netmask: 255.255.255.255
       netmask6: 1
 
-- name: Delete a10_slb_template_persist_source_ip example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_persist_source_ip example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_persist_source_ip instance
-    a10_slb_template_persist_source_ip:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_persist_source_ip instance
+    a10.acos_axapi.a10_slb_template_persist_source_ip:
       state: absent
       name: my_source-ip
       timeout: 1

--- a/examples/single_task/slb/template/a10_slb_template_persist_source_ip_create.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_persist_source_ip_create.yaml
@@ -1,14 +1,9 @@
-- name: Create a10_slb_template_persist_source_ip example playbook
+- name: Create a10.acos_axapi.a10_slb_template_persist_source_ip example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_persist_source_ip instance
-    a10_slb_template_persist_source_ip:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_slb_template_persist_source_ip instance
+    a10.acos_axapi.a10_slb_template_persist_source_ip:
       name: my_source-ip
       timeout: 1
       netmask: 255.255.255.255

--- a/examples/single_task/slb/template/a10_slb_template_persist_source_ip_delete.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_persist_source_ip_delete.yaml
@@ -1,14 +1,9 @@
-- name: Delete a10_slb_template_persist_source_ip example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_persist_source_ip example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_persist_source_ip instance
-    a10_slb_template_persist_source_ip:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_persist_source_ip instance
+    a10.acos_axapi.a10_slb_template_persist_source_ip:
       state: absent
       name: my_source-ip
       timeout: 1

--- a/examples/single_task/slb/template/a10_slb_template_persist_source_ip_update.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_persist_source_ip_update.yaml
@@ -1,14 +1,9 @@
-- name: Update a10_slb_template_persist_source_ip example playbook
+- name: Update a10.acos_axapi.a10_slb_template_persist_source_ip example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_persist_source_ip instance
-    a10_slb_template_persist_source_ip:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Update a10.acos_axapi.a10_slb_template_persist_source_ip instance
+    a10.acos_axapi.a10_slb_template_persist_source_ip:
       state: present
       name: my_source-ip
       timeout: 1

--- a/examples/single_task/slb/template/a10_slb_template_persist_ssl_sid.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_persist_ssl_sid.yaml
@@ -1,39 +1,30 @@
 
 
-- name: Create a10_slb_template_persist_ssl_sid example playbook
+- name: Create a10.acos_axapi.a10_slb_template_persist_ssl_sid example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_persist_ssl_sid instance
-    a10_slb_template_persist_ssl_sid:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_slb_template_persist_ssl_sid instance
+    a10.acos_axapi.a10_slb_template_persist_ssl_sid:
       name: my_ssl-sid
       timeout: 1
 
-- name: Update a10_slb_template_persist_ssl_sid example playbook
+- name: Update a10.acos_axapi.a10_slb_template_persist_ssl_sid example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_persist_ssl_sid instance
-    a10_slb_template_persist_ssl_sid:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_slb_template_persist_ssl_sid instance
+    a10.acos_axapi.a10_slb_template_persist_ssl_sid:
       state: present
       name: my_ssl-sid
       timeout: 1
 
-- name: Delete a10_slb_template_persist_ssl_sid example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_persist_ssl_sid example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_persist_ssl_sid instance
-    a10_slb_template_persist_ssl_sid:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_persist_ssl_sid instance
+    a10.acos_axapi.a10_slb_template_persist_ssl_sid:
       state: absent
       name: my_ssl-sid
       timeout: 1

--- a/examples/single_task/slb/template/a10_slb_template_persist_ssl_sid_create.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_persist_ssl_sid_create.yaml
@@ -1,13 +1,8 @@
-- name: Create a10_slb_template_persist_ssl_sid example playbook
+- name: Create a10.acos_axapi.a10_slb_template_persist_ssl_sid example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_persist_ssl_sid instance
-    a10_slb_template_persist_ssl_sid:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_slb_template_persist_ssl_sid instance
+    a10.acos_axapi.a10_slb_template_persist_ssl_sid:
       name: my_ssl-sid
       timeout: 1

--- a/examples/single_task/slb/template/a10_slb_template_persist_ssl_sid_delete.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_persist_ssl_sid_delete.yaml
@@ -1,14 +1,9 @@
-- name: Delete a10_slb_template_persist_ssl_sid example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_persist_ssl_sid example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_persist_ssl_sid instance
-    a10_slb_template_persist_ssl_sid:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_persist_ssl_sid instance
+    a10.acos_axapi.a10_slb_template_persist_ssl_sid:
       state: absent
       name: my_ssl-sid
       timeout: 1

--- a/examples/single_task/slb/template/a10_slb_template_persist_ssl_sid_update.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_persist_ssl_sid_update.yaml
@@ -1,14 +1,9 @@
-- name: Update a10_slb_template_persist_ssl_sid example playbook
+- name: Update a10.acos_axapi.a10_slb_template_persist_ssl_sid example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_persist_ssl_sid instance
-    a10_slb_template_persist_ssl_sid:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Update a10.acos_axapi.a10_slb_template_persist_ssl_sid instance
+    a10.acos_axapi.a10_slb_template_persist_ssl_sid:
       state: present
       name: my_ssl-sid
       timeout: 1

--- a/examples/single_task/slb/template/a10_slb_template_policy.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_policy.yaml
@@ -1,39 +1,30 @@
 
 
-- name: Create a10_slb_template_policy example playbook
+- name: Create a10.acos_axapi.a10_slb_template_policy example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_policy instance
-    a10_slb_template_policy:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_slb_template_policy instance
+    a10.acos_axapi.a10_slb_template_policy:
       name: my_policy
       timeout: 1
 
-- name: Update a10_slb_template_policy example playbook
+- name: Update a10.acos_axapi.a10_slb_template_policy example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_policy instance
-    a10_slb_template_policy:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_slb_template_policy instance
+    a10.acos_axapi.a10_slb_template_policy:
       state: present
       name: my_policy
       timeout: 1
 
-- name: Delete a10_slb_template_policy example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_policy example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_policy instance
-    a10_slb_template_policy:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_policy instance
+    a10.acos_axapi.a10_slb_template_policy:
       state: absent
       name: my_policy
       timeout: 1

--- a/examples/single_task/slb/template/a10_slb_template_policy_class_list_lid.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_policy_class_list_lid.yaml
@@ -1,41 +1,32 @@
 
 
-- name: Create a10_slb_template_policy_class_list_lid example playbook
+- name: Create a10.acos_axapi.a10_slb_template_policy_class_list_lid example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_policy_class_list_lid instance
-    a10_slb_template_policy_class_list_lid:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_slb_template_policy_class_list_lid instance
+    a10.acos_axapi.a10_slb_template_policy_class_list_lid:
       lidnum: 1
       direct_pbslb_interval: 0
       direct_action_interval: 0
 
-- name: Update a10_slb_template_policy_class_list_lid example playbook
+- name: Update a10.acos_axapi.a10_slb_template_policy_class_list_lid example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_policy_class_list_lid instance
-    a10_slb_template_policy_class_list_lid:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_slb_template_policy_class_list_lid instance
+    a10.acos_axapi.a10_slb_template_policy_class_list_lid:
       state: present
       lidnum: 1
       direct_pbslb_interval: 0
       direct_action_interval: 0
 
-- name: Delete a10_slb_template_policy_class_list_lid example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_policy_class_list_lid example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_policy_class_list_lid instance
-    a10_slb_template_policy_class_list_lid:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_policy_class_list_lid instance
+    a10.acos_axapi.a10_slb_template_policy_class_list_lid:
       state: absent
       lidnum: 1
       direct_pbslb_interval: 0

--- a/examples/single_task/slb/template/a10_slb_template_policy_create.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_policy_create.yaml
@@ -1,13 +1,8 @@
-- name: Create a10_slb_template_policy example playbook
+- name: Create a10.acos_axapi.a10_slb_template_policy example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_policy instance
-    a10_slb_template_policy:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_slb_template_policy instance
+    a10.acos_axapi.a10_slb_template_policy:
       name: my_policy
       timeout: 1

--- a/examples/single_task/slb/template/a10_slb_template_policy_delete.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_policy_delete.yaml
@@ -1,14 +1,9 @@
-- name: Delete a10_slb_template_policy example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_policy example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_policy instance
-    a10_slb_template_policy:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_policy instance
+    a10.acos_axapi.a10_slb_template_policy:
       state: absent
       name: my_policy
       timeout: 1

--- a/examples/single_task/slb/template/a10_slb_template_policy_forward_policy_action.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_policy_forward_policy_action.yaml
@@ -1,39 +1,30 @@
 
 
-- name: Create a10_slb_template_policy_forward_policy_action example playbook
+- name: Create a10.acos_axapi.a10_slb_template_policy_forward_policy_action example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_policy_forward_policy_action instance
-    a10_slb_template_policy_forward_policy_action:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_slb_template_policy_forward_policy_action instance
+    a10.acos_axapi.a10_slb_template_policy_forward_policy_action:
       name: my_action
       http_status_code: 302
 
-- name: Update a10_slb_template_policy_forward_policy_action example playbook
+- name: Update a10.acos_axapi.a10_slb_template_policy_forward_policy_action example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_policy_forward_policy_action instance
-    a10_slb_template_policy_forward_policy_action:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_slb_template_policy_forward_policy_action instance
+    a10.acos_axapi.a10_slb_template_policy_forward_policy_action:
       state: present
       name: my_action
       http_status_code: 302
 
-- name: Delete a10_slb_template_policy_forward_policy_action example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_policy_forward_policy_action example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_policy_forward_policy_action instance
-    a10_slb_template_policy_forward_policy_action:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_policy_forward_policy_action instance
+    a10.acos_axapi.a10_slb_template_policy_forward_policy_action:
       state: absent
       name: my_action
       http_status_code: 302

--- a/examples/single_task/slb/template/a10_slb_template_policy_forward_policy_action_create.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_policy_forward_policy_action_create.yaml
@@ -1,13 +1,8 @@
-- name: Create a10_slb_template_policy_forward_policy_action example playbook
+- name: Create a10.acos_axapi.a10_slb_template_policy_forward_policy_action example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_policy_forward_policy_action instance
-    a10_slb_template_policy_forward_policy_action:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_slb_template_policy_forward_policy_action instance
+    a10.acos_axapi.a10_slb_template_policy_forward_policy_action:
       policy_name: "my_policy"
       name: my_action

--- a/examples/single_task/slb/template/a10_slb_template_policy_forward_policy_action_delete.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_policy_forward_policy_action_delete.yaml
@@ -1,14 +1,9 @@
-- name: Delete a10_slb_template_policy_forward_policy_action example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_policy_forward_policy_action example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_policy_forward_policy_action instance
-    a10_slb_template_policy_forward_policy_action:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_policy_forward_policy_action instance
+    a10.acos_axapi.a10_slb_template_policy_forward_policy_action:
       state: absent
       policy_name: "my_policy"
       name: my_action

--- a/examples/single_task/slb/template/a10_slb_template_policy_forward_policy_action_update.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_policy_forward_policy_action_update.yaml
@@ -1,14 +1,9 @@
-- name: Update a10_slb_template_policy_forward_policy_action example playbook
+- name: Update a10.acos_axapi.a10_slb_template_policy_forward_policy_action example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_policy_forward_policy_action instance
-    a10_slb_template_policy_forward_policy_action:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Update a10.acos_axapi.a10_slb_template_policy_forward_policy_action instance
+    a10.acos_axapi.a10_slb_template_policy_forward_policy_action:
       state: present
       policy_name: my_policy
       name: my_action

--- a/examples/single_task/slb/template/a10_slb_template_policy_forward_policy_source.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_policy_forward_policy_source.yaml
@@ -1,36 +1,27 @@
 
 
-- name: Create a10_slb_template_policy_forward_policy_source example playbook
+- name: Create a10.acos_axapi.a10_slb_template_policy_forward_policy_source example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_policy_forward_policy_source instance
-    a10_slb_template_policy_forward_policy_source:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_slb_template_policy_forward_policy_source instance
+    a10.acos_axapi.a10_slb_template_policy_forward_policy_source:
       name: my_source
 
-- name: Update a10_slb_template_policy_forward_policy_source example playbook
+- name: Update a10.acos_axapi.a10_slb_template_policy_forward_policy_source example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_policy_forward_policy_source instance
-    a10_slb_template_policy_forward_policy_source:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_slb_template_policy_forward_policy_source instance
+    a10.acos_axapi.a10_slb_template_policy_forward_policy_source:
       state: present
       name: my_source
 
-- name: Delete a10_slb_template_policy_forward_policy_source example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_policy_forward_policy_source example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_policy_forward_policy_source instance
-    a10_slb_template_policy_forward_policy_source:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_policy_forward_policy_source instance
+    a10.acos_axapi.a10_slb_template_policy_forward_policy_source:
       state: absent
       name: my_source

--- a/examples/single_task/slb/template/a10_slb_template_policy_forward_policy_source_create.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_policy_forward_policy_source_create.yaml
@@ -1,13 +1,8 @@
-- name: Create a10_slb_template_policy_forward_policy_source example playbook
+- name: Create a10.acos_axapi.a10_slb_template_policy_forward_policy_source example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_policy_forward_policy_source instance
-    a10_slb_template_policy_forward_policy_source:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_slb_template_policy_forward_policy_source instance
+    a10.acos_axapi.a10_slb_template_policy_forward_policy_source:
       name: my_source
       policy_name: my_policy

--- a/examples/single_task/slb/template/a10_slb_template_policy_forward_policy_source_delete.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_policy_forward_policy_source_delete.yaml
@@ -1,14 +1,9 @@
-- name: Delete a10_slb_template_policy_forward_policy_source example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_policy_forward_policy_source example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_policy_forward_policy_source instance
-    a10_slb_template_policy_forward_policy_source:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_policy_forward_policy_source instance
+    a10.acos_axapi.a10_slb_template_policy_forward_policy_source:
       state: absent
       name: my_source
       policy_name: my_policy

--- a/examples/single_task/slb/template/a10_slb_template_policy_forward_policy_source_destination_class_list.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_policy_forward_policy_source_destination_class_list.yaml
@@ -1,36 +1,27 @@
 
 
-- name: Create a10_slb_template_policy_forward_policy_source_destination_class_list example playbook
+- name: Create a10.acos_axapi.a10_slb_template_policy_forward_policy_source_destination_class_list example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_policy_forward_policy_source_destination_class_list instance
-    a10_slb_template_policy_forward_policy_source_destination_class_list:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_slb_template_policy_forward_policy_source_destination_class_list instance
+    a10.acos_axapi.a10_slb_template_policy_forward_policy_source_destination_class_list:
       dest_class_list: NO_EXAMPLE
 
-- name: Update a10_slb_template_policy_forward_policy_source_destination_class_list example playbook
+- name: Update a10.acos_axapi.a10_slb_template_policy_forward_policy_source_destination_class_list example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_policy_forward_policy_source_destination_class_list instance
-    a10_slb_template_policy_forward_policy_source_destination_class_list:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_slb_template_policy_forward_policy_source_destination_class_list instance
+    a10.acos_axapi.a10_slb_template_policy_forward_policy_source_destination_class_list:
       state: present
       dest_class_list: NO_EXAMPLE
 
-- name: Delete a10_slb_template_policy_forward_policy_source_destination_class_list example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_policy_forward_policy_source_destination_class_list example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_policy_forward_policy_source_destination_class_list instance
-    a10_slb_template_policy_forward_policy_source_destination_class_list:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_policy_forward_policy_source_destination_class_list instance
+    a10.acos_axapi.a10_slb_template_policy_forward_policy_source_destination_class_list:
       state: absent
       dest_class_list: NO_EXAMPLE

--- a/examples/single_task/slb/template/a10_slb_template_policy_forward_policy_source_destination_web_category_list.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_policy_forward_policy_source_destination_web_category_list.yaml
@@ -1,36 +1,27 @@
 
 
-- name: Create a10_slb_template_policy_forward_policy_source_destination_web_category_list example playbook
+- name: Create a10.acos_axapi.a10_slb_template_policy_forward_policy_source_destination_web_category_list example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_policy_forward_policy_source_destination_web_category_list instance
-    a10_slb_template_policy_forward_policy_source_destination_web_category_list:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_slb_template_policy_forward_policy_source_destination_web_category_list instance
+    a10.acos_axapi.a10_slb_template_policy_forward_policy_source_destination_web_category_list:
       web_category_list: NO_EXAMPLE
 
-- name: Update a10_slb_template_policy_forward_policy_source_destination_web_category_list example playbook
+- name: Update a10.acos_axapi.a10_slb_template_policy_forward_policy_source_destination_web_category_list example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_policy_forward_policy_source_destination_web_category_list instance
-    a10_slb_template_policy_forward_policy_source_destination_web_category_list:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_slb_template_policy_forward_policy_source_destination_web_category_list instance
+    a10.acos_axapi.a10_slb_template_policy_forward_policy_source_destination_web_category_list:
       state: present
       web_category_list: NO_EXAMPLE
 
-- name: Delete a10_slb_template_policy_forward_policy_source_destination_web_category_list example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_policy_forward_policy_source_destination_web_category_list example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_policy_forward_policy_source_destination_web_category_list instance
-    a10_slb_template_policy_forward_policy_source_destination_web_category_list:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_policy_forward_policy_source_destination_web_category_list instance
+    a10.acos_axapi.a10_slb_template_policy_forward_policy_source_destination_web_category_list:
       state: absent
       web_category_list: NO_EXAMPLE

--- a/examples/single_task/slb/template/a10_slb_template_policy_forward_policy_source_update.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_policy_forward_policy_source_update.yaml
@@ -1,14 +1,9 @@
-- name: Update a10_slb_template_policy_forward_policy_source example playbook
+- name: Update a10.acos_axapi.a10_slb_template_policy_forward_policy_source example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_policy_forward_policy_source instance
-    a10_slb_template_policy_forward_policy_source:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Update a10.acos_axapi.a10_slb_template_policy_forward_policy_source instance
+    a10.acos_axapi.a10_slb_template_policy_forward_policy_source:
       state: present
       name: my_source
       policy_name: my_policy

--- a/examples/single_task/slb/template/a10_slb_template_policy_update.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_policy_update.yaml
@@ -1,14 +1,9 @@
-- name: Update a10_slb_template_policy example playbook
+- name: Update a10.acos_axapi.a10_slb_template_policy example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_policy instance
-    a10_slb_template_policy:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Update a10.acos_axapi.a10_slb_template_policy instance
+    a10.acos_axapi.a10_slb_template_policy:
       state: present
       name: my_policy
       timeout: 1

--- a/examples/single_task/slb/template/a10_slb_template_port.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_port.yaml
@@ -1,14 +1,11 @@
 
 
-- name: Create a10_slb_template_port example playbook
+- name: Create a10.acos_axapi.a10_slb_template_port example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_port instance
-    a10_slb_template_port:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_slb_template_port instance
+    a10.acos_axapi.a10_slb_template_port:
       name: default
       conn_limit: 1
       rate_interval: second
@@ -23,15 +20,12 @@
       every: 1
       till: 1
 
-- name: Update a10_slb_template_port example playbook
+- name: Update a10.acos_axapi.a10_slb_template_port example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_port instance
-    a10_slb_template_port:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_slb_template_port instance
+    a10.acos_axapi.a10_slb_template_port:
       state: present
       name: default
       conn_limit: 1
@@ -47,15 +41,12 @@
       every: 1
       till: 1
 
-- name: Delete a10_slb_template_port example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_port example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_port instance
-    a10_slb_template_port:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_port instance
+    a10.acos_axapi.a10_slb_template_port:
       state: absent
       name: default
       conn_limit: 1

--- a/examples/single_task/slb/template/a10_slb_template_port_create.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_port_create.yaml
@@ -1,14 +1,9 @@
-- name: Create a10_slb_template_port example playbook
+- name: Create a10.acos_axapi.a10_slb_template_port example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_port instance
-    a10_slb_template_port:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_slb_template_port instance
+    a10.acos_axapi.a10_slb_template_port:
       name: default
       conn_limit: 1
       dynamic_member_priority: 1

--- a/examples/single_task/slb/template/a10_slb_template_port_delete.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_port_delete.yaml
@@ -1,14 +1,9 @@
-- name: Update a10_slb_template_port example playbook
+- name: Update a10.acos_axapi.a10_slb_template_port example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_port instance
-    a10_slb_template_port:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Update a10.acos_axapi.a10_slb_template_port instance
+    a10.acos_axapi.a10_slb_template_port:
       state: absent
       name: default
       conn_limit: 1

--- a/examples/single_task/slb/template/a10_slb_template_port_update.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_port_update.yaml
@@ -1,14 +1,9 @@
-- name: Update a10_slb_template_port example playbook
+- name: Update a10.acos_axapi.a10_slb_template_port example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_port instance
-    a10_slb_template_port:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Update a10.acos_axapi.a10_slb_template_port instance
+    a10.acos_axapi.a10_slb_template_port:
       state: present
       name: default
       conn_limit: 1

--- a/examples/single_task/slb/template/a10_slb_template_reqmod_icap.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_reqmod_icap.yaml
@@ -1,41 +1,32 @@
 
 
-- name: Create a10_slb_template_reqmod_icap example playbook
+- name: Create a10.acos_axapi.a10_slb_template_reqmod_icap example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_reqmod_icap instance
-    a10_slb_template_reqmod_icap:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_slb_template_reqmod_icap instance
+    a10.acos_axapi.a10_slb_template_reqmod_icap:
       name: my_reqmod-icap
       action: continue
       preview: 1
 
-- name: Update a10_slb_template_reqmod_icap example playbook
+- name: Update a10.acos_axapi.a10_slb_template_reqmod_icap example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_reqmod_icap instance
-    a10_slb_template_reqmod_icap:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_slb_template_reqmod_icap instance
+    a10.acos_axapi.a10_slb_template_reqmod_icap:
       state: present
       name: my_reqmod-icap
       action: continue
       preview: 1
 
-- name: Delete a10_slb_template_reqmod_icap example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_reqmod_icap example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_reqmod_icap instance
-    a10_slb_template_reqmod_icap:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_reqmod_icap instance
+    a10.acos_axapi.a10_slb_template_reqmod_icap:
       state: absent
       name: my_reqmod-icap
       action: continue

--- a/examples/single_task/slb/template/a10_slb_template_reqmod_icap_create.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_reqmod_icap_create.yaml
@@ -1,13 +1,8 @@
-- name: Create a10_slb_template_reqmod_icap example playbook
+- name: Create a10.acos_axapi.a10_slb_template_reqmod_icap example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_reqmod_icap instance
-    a10_slb_template_reqmod_icap:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_slb_template_reqmod_icap instance
+    a10.acos_axapi.a10_slb_template_reqmod_icap:
       name: my_reqmod-icap
       preview: 1

--- a/examples/single_task/slb/template/a10_slb_template_reqmod_icap_delete.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_reqmod_icap_delete.yaml
@@ -1,14 +1,9 @@
-- name: Update a10_slb_template_reqmod_icap example playbook
+- name: Update a10.acos_axapi.a10_slb_template_reqmod_icap example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_reqmod_icap instance
-    a10_slb_template_reqmod_icap:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Update a10.acos_axapi.a10_slb_template_reqmod_icap instance
+    a10.acos_axapi.a10_slb_template_reqmod_icap:
       state: absent
       name: my_reqmod-icap
       preview: 1

--- a/examples/single_task/slb/template/a10_slb_template_reqmod_icap_update.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_reqmod_icap_update.yaml
@@ -1,14 +1,9 @@
-- name: Update a10_slb_template_reqmod_icap example playbook
+- name: Update a10.acos_axapi.a10_slb_template_reqmod_icap example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_reqmod_icap instance
-    a10_slb_template_reqmod_icap:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Update a10.acos_axapi.a10_slb_template_reqmod_icap instance
+    a10.acos_axapi.a10_slb_template_reqmod_icap:
       state: present
       name: my_reqmod-icap
       preview: 1

--- a/examples/single_task/slb/template/a10_slb_template_respmod_icap.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_respmod_icap.yaml
@@ -1,41 +1,32 @@
 
 
-- name: Create a10_slb_template_respmod_icap example playbook
+- name: Create a10.acos_axapi.a10_slb_template_respmod_icap example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_respmod_icap instance
-    a10_slb_template_respmod_icap:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_slb_template_respmod_icap instance
+    a10.acos_axapi.a10_slb_template_respmod_icap:
       name: my_respmod-icap
       action: continue
       preview: 1
 
-- name: Update a10_slb_template_respmod_icap example playbook
+- name: Update a10.acos_axapi.a10_slb_template_respmod_icap example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_respmod_icap instance
-    a10_slb_template_respmod_icap:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_slb_template_respmod_icap instance
+    a10.acos_axapi.a10_slb_template_respmod_icap:
       state: present
       name: my_respmod-icap
       action: continue
       preview: 1
 
-- name: Delete a10_slb_template_respmod_icap example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_respmod_icap example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_respmod_icap instance
-    a10_slb_template_respmod_icap:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_respmod_icap instance
+    a10.acos_axapi.a10_slb_template_respmod_icap:
       state: absent
       name: my_respmod-icap
       action: continue

--- a/examples/single_task/slb/template/a10_slb_template_respmod_icap_create.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_respmod_icap_create.yaml
@@ -1,13 +1,8 @@
-- name: Create a10_slb_template_respmod_icap example playbook
+- name: Create a10.acos_axapi.a10_slb_template_respmod_icap example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_respmod_icap instance
-    a10_slb_template_respmod_icap:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_slb_template_respmod_icap instance
+    a10.acos_axapi.a10_slb_template_respmod_icap:
       name: my_respmod-icap
       preview: 1

--- a/examples/single_task/slb/template/a10_slb_template_respmod_icap_delete.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_respmod_icap_delete.yaml
@@ -1,14 +1,9 @@
-- name: Update a10_slb_template_respmod_icap example playbook
+- name: Update a10.acos_axapi.a10_slb_template_respmod_icap example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_respmod_icap instance
-    a10_slb_template_respmod_icap:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Update a10.acos_axapi.a10_slb_template_respmod_icap instance
+    a10.acos_axapi.a10_slb_template_respmod_icap:
       state: absent
       name: my_respmod-icap
       preview: 1

--- a/examples/single_task/slb/template/a10_slb_template_respmod_icap_update.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_respmod_icap_update.yaml
@@ -1,14 +1,9 @@
-- name: Update a10_slb_template_respmod_icap example playbook
+- name: Update a10.acos_axapi.a10_slb_template_respmod_icap example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_respmod_icap instance
-    a10_slb_template_respmod_icap:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Update a10.acos_axapi.a10_slb_template_respmod_icap instance
+    a10.acos_axapi.a10_slb_template_respmod_icap:
       state: present
       name: my_respmod-icap
       preview: 1

--- a/examples/single_task/slb/template/a10_slb_template_server.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_server.yaml
@@ -1,14 +1,11 @@
 
 
-- name: Create a10_slb_template_server example playbook
+- name: Create a10.acos_axapi.a10_slb_template_server example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_server instance
-    a10_slb_template_server:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_slb_template_server instance
+    a10.acos_axapi.a10_slb_template_server:
       name: default
       conn_limit: 1
       rate_interval: second
@@ -24,15 +21,12 @@
       till: 1
       bw_rate_limit_acct: all
 
-- name: Update a10_slb_template_server example playbook
+- name: Update a10.acos_axapi.a10_slb_template_server example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_server instance
-    a10_slb_template_server:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_slb_template_server instance
+    a10.acos_axapi.a10_slb_template_server:
       state: present
       name: default
       conn_limit: 1
@@ -49,15 +43,12 @@
       till: 1
       bw_rate_limit_acct: all
 
-- name: Delete a10_slb_template_server example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_server example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_server instance
-    a10_slb_template_server:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_server instance
+    a10.acos_axapi.a10_slb_template_server:
       state: absent
       name: default
       conn_limit: 1

--- a/examples/single_task/slb/template/a10_slb_template_server_create.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_server_create.yaml
@@ -1,14 +1,9 @@
-- name: Create a10_slb_template_server example playbook
+- name: Create a10.acos_axapi.a10_slb_template_server example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_server instance
-    a10_slb_template_server:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_slb_template_server instance
+    a10.acos_axapi.a10_slb_template_server:
       name: default
       conn_limit: 1
       dns_query_interval: 1

--- a/examples/single_task/slb/template/a10_slb_template_server_delete.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_server_delete.yaml
@@ -1,14 +1,9 @@
-- name: Delete a10_slb_template_server example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_server example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_server instance
-    a10_slb_template_server:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_server instance
+    a10.acos_axapi.a10_slb_template_server:
       name: default
       state: absent
       conn_limit: 1

--- a/examples/single_task/slb/template/a10_slb_template_server_ssl.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_server_ssl.yaml
@@ -1,41 +1,32 @@
 
 
-- name: Create a10_slb_template_server_ssl example playbook
+- name: Create a10.acos_axapi.a10_slb_template_server_ssl example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_server_ssl instance
-    a10_slb_template_server_ssl:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_slb_template_server_ssl instance
+    a10.acos_axapi.a10_slb_template_server_ssl:
       name: my_server-ssl
       version: 30
       dgversion: 30
 
-- name: Update a10_slb_template_server_ssl example playbook
+- name: Update a10.acos_axapi.a10_slb_template_server_ssl example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_server_ssl instance
-    a10_slb_template_server_ssl:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_slb_template_server_ssl instance
+    a10.acos_axapi.a10_slb_template_server_ssl:
       state: present
       name: my_server-ssl
       version: 30
       dgversion: 30
 
-- name: Delete a10_slb_template_server_ssl example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_server_ssl example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_server_ssl instance
-    a10_slb_template_server_ssl:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_server_ssl instance
+    a10.acos_axapi.a10_slb_template_server_ssl:
       state: absent
       name: my_server-ssl
       version: 30

--- a/examples/single_task/slb/template/a10_slb_template_server_ssl_create.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_server_ssl_create.yaml
@@ -1,14 +1,9 @@
-- name: Create a10_slb_template_server_ssl example playbook
+- name: Create a10.acos_axapi.a10_slb_template_server_ssl example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_server_ssl instance
-    a10_slb_template_server_ssl:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_slb_template_server_ssl instance
+    a10.acos_axapi.a10_slb_template_server_ssl:
       name: my_server-ssl
       version: 30
       dgversion: 30

--- a/examples/single_task/slb/template/a10_slb_template_server_ssl_delete.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_server_ssl_delete.yaml
@@ -1,14 +1,9 @@
-- name: Delete a10_slb_template_server_ssl example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_server_ssl example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_server_ssl instance
-    a10_slb_template_server_ssl:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_server_ssl instance
+    a10.acos_axapi.a10_slb_template_server_ssl:
       state: absent
       name: my_server-ssl
       version: 30

--- a/examples/single_task/slb/template/a10_slb_template_server_ssl_update.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_server_ssl_update.yaml
@@ -1,14 +1,9 @@
-- name: Update a10_slb_template_server_ssl example playbook
+- name: Update a10.acos_axapi.a10_slb_template_server_ssl example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_server_ssl instance
-    a10_slb_template_server_ssl:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Update a10.acos_axapi.a10_slb_template_server_ssl instance
+    a10.acos_axapi.a10_slb_template_server_ssl:
       state: present
       name: my_server-ssl
       version: 30

--- a/examples/single_task/slb/template/a10_slb_template_server_update.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_server_update.yaml
@@ -1,14 +1,9 @@
-- name: Create a10_slb_template_server example playbook
+- name: Create a10.acos_axapi.a10_slb_template_server example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_server instance
-    a10_slb_template_server:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_slb_template_server instance
+    a10.acos_axapi.a10_slb_template_server:
       name: default
       state: present
       conn_limit: 1

--- a/examples/single_task/slb/template/a10_slb_template_sip.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_sip.yaml
@@ -1,43 +1,34 @@
 
 
-- name: Create a10_slb_template_sip example playbook
+- name: Create a10.acos_axapi.a10_slb_template_sip example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_sip instance
-    a10_slb_template_sip:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_slb_template_sip instance
+    a10.acos_axapi.a10_slb_template_sip:
       name: my_sip
       pstn_gw: pstn
       interval: 5
       timeout: 1
 
-- name: Update a10_slb_template_sip example playbook
+- name: Update a10.acos_axapi.a10_slb_template_sip example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_sip instance
-    a10_slb_template_sip:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_slb_template_sip instance
+    a10.acos_axapi.a10_slb_template_sip:
       state: present
       name: my_sip
       pstn_gw: pstn
       interval: 5
       timeout: 1
 
-- name: Delete a10_slb_template_sip example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_sip example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_sip instance
-    a10_slb_template_sip:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_sip instance
+    a10.acos_axapi.a10_slb_template_sip:
       state: absent
       name: my_sip
       pstn_gw: pstn

--- a/examples/single_task/slb/template/a10_slb_template_sip_create.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_sip_create.yaml
@@ -1,14 +1,9 @@
-- name: Create a10_slb_template_sip example playbook
+- name: Create a10.acos_axapi.a10_slb_template_sip example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_sip instance
-    a10_slb_template_sip:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_slb_template_sip instance
+    a10.acos_axapi.a10_slb_template_sip:
       name: my_sip
       pstn_gw: pstn
       timeout: 1

--- a/examples/single_task/slb/template/a10_slb_template_sip_delete.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_sip_delete.yaml
@@ -1,14 +1,9 @@
-- name: Update a10_slb_template_sip example playbook
+- name: Update a10.acos_axapi.a10_slb_template_sip example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_sip instance
-    a10_slb_template_sip:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Update a10.acos_axapi.a10_slb_template_sip instance
+    a10.acos_axapi.a10_slb_template_sip:
       state: absent
       name: my_sip
       pstn_gw: pstn

--- a/examples/single_task/slb/template/a10_slb_template_sip_update.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_sip_update.yaml
@@ -1,14 +1,9 @@
-- name: Update a10_slb_template_sip example playbook
+- name: Update a10.acos_axapi.a10_slb_template_sip example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_sip instance
-    a10_slb_template_sip:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Update a10.acos_axapi.a10_slb_template_sip instance
+    a10.acos_axapi.a10_slb_template_sip:
       state: present
       name: my_sip
       pstn_gw: pstn

--- a/examples/single_task/slb/template/a10_slb_template_smpp.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_smpp.yaml
@@ -1,39 +1,30 @@
 
 
-- name: Create a10_slb_template_smpp example playbook
+- name: Create a10.acos_axapi.a10_slb_template_smpp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_smpp instance
-    a10_slb_template_smpp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_slb_template_smpp instance
+    a10.acos_axapi.a10_slb_template_smpp:
       name: my_smpp
       server_enquire_link_val: 5
 
-- name: Update a10_slb_template_smpp example playbook
+- name: Update a10.acos_axapi.a10_slb_template_smpp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_smpp instance
-    a10_slb_template_smpp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_slb_template_smpp instance
+    a10.acos_axapi.a10_slb_template_smpp:
       state: present
       name: my_smpp
       server_enquire_link_val: 5
 
-- name: Delete a10_slb_template_smpp example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_smpp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_smpp instance
-    a10_slb_template_smpp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_smpp instance
+    a10.acos_axapi.a10_slb_template_smpp:
       state: absent
       name: my_smpp
       server_enquire_link_val: 5

--- a/examples/single_task/slb/template/a10_slb_template_smpp_create.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_smpp_create.yaml
@@ -1,12 +1,7 @@
-- name: Create a10_slb_template_smpp example playbook
+- name: Create a10.acos_axapi.a10_slb_template_smpp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_smpp instance
-    a10_slb_template_smpp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_slb_template_smpp instance
+    a10.acos_axapi.a10_slb_template_smpp:
       name: my_smpp

--- a/examples/single_task/slb/template/a10_slb_template_smpp_delete.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_smpp_delete.yaml
@@ -1,13 +1,8 @@
-- name: Delete a10_slb_template_smpp example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_smpp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_smpp instance
-    a10_slb_template_smpp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_smpp instance
+    a10.acos_axapi.a10_slb_template_smpp:
       state: absent
       name: my_smpp

--- a/examples/single_task/slb/template/a10_slb_template_smpp_update.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_smpp_update.yaml
@@ -1,13 +1,8 @@
-- name: Update a10_slb_template_smpp example playbook
+- name: Update a10.acos_axapi.a10_slb_template_smpp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_smpp instance
-    a10_slb_template_smpp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Update a10.acos_axapi.a10_slb_template_smpp instance
+    a10.acos_axapi.a10_slb_template_smpp:
       state: present
       name: my_smpp

--- a/examples/single_task/slb/template/a10_slb_template_smtp.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_smtp.yaml
@@ -1,41 +1,32 @@
 
 
-- name: Create a10_slb_template_smtp example playbook
+- name: Create a10.acos_axapi.a10_slb_template_smtp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_smtp instance
-    a10_slb_template_smtp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_slb_template_smtp instance
+    a10.acos_axapi.a10_slb_template_smtp:
       name: my_smtp
       server_domain: "mail-server-domain"
       service_ready_msg: ESMTP mail service ready
 
-- name: Update a10_slb_template_smtp example playbook
+- name: Update a10.acos_axapi.a10_slb_template_smtp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_smtp instance
-    a10_slb_template_smtp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_slb_template_smtp instance
+    a10.acos_axapi.a10_slb_template_smtp:
       state: present
       name: my_smtp
       server_domain: "mail-server-domain"
       service_ready_msg: ESMTP mail service ready
 
-- name: Delete a10_slb_template_smtp example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_smtp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_smtp instance
-    a10_slb_template_smtp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_smtp instance
+    a10.acos_axapi.a10_slb_template_smtp:
       state: absent
       name: my_smtp
       server_domain: "mail-server-domain"

--- a/examples/single_task/slb/template/a10_slb_template_smtp_create.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_smtp_create.yaml
@@ -1,14 +1,9 @@
-- name: Create a10_slb_template_smtp example playbook
+- name: Create a10.acos_axapi.a10_slb_template_smtp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_smtp instance
-    a10_slb_template_smtp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_slb_template_smtp instance
+    a10.acos_axapi.a10_slb_template_smtp:
       name: my_smtp
       server_domain: "mail-server-domain"
       service_ready_msg: ESMTP mail service ready

--- a/examples/single_task/slb/template/a10_slb_template_smtp_delete.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_smtp_delete.yaml
@@ -1,14 +1,9 @@
-- name: Delete a10_slb_template_smtp example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_smtp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_smtp instance
-    a10_slb_template_smtp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_smtp instance
+    a10.acos_axapi.a10_slb_template_smtp:
       state: absent
       name: my_smtp
       server_domain: "mail-server-domain"

--- a/examples/single_task/slb/template/a10_slb_template_smtp_update.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_smtp_update.yaml
@@ -1,14 +1,9 @@
-- name: Update a10_slb_template_smtp example playbook
+- name: Update a10.acos_axapi.a10_slb_template_smtp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_smtp instance
-    a10_slb_template_smtp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Update a10.acos_axapi.a10_slb_template_smtp instance
+    a10.acos_axapi.a10_slb_template_smtp:
       state: present
       name: my_smtp
       server_domain: "mail-server-domain"

--- a/examples/single_task/slb/template/a10_slb_template_ssli.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_ssli.yaml
@@ -1,39 +1,30 @@
 
 
-- name: Create a10_slb_template_ssli example playbook
+- name: Create a10.acos_axapi.a10_slb_template_ssli example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_ssli instance
-    a10_slb_template_ssli:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_slb_template_ssli instance
+    a10.acos_axapi.a10_slb_template_ssli:
       name: my_ssli
       type: http
 
-- name: Update a10_slb_template_ssli example playbook
+- name: Update a10.acos_axapi.a10_slb_template_ssli example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_ssli instance
-    a10_slb_template_ssli:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_slb_template_ssli instance
+    a10.acos_axapi.a10_slb_template_ssli:
       state: present
       name: my_ssli
       type: http
 
-- name: Delete a10_slb_template_ssli example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_ssli example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_ssli instance
-    a10_slb_template_ssli:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_ssli instance
+    a10.acos_axapi.a10_slb_template_ssli:
       state: absent
       name: my_ssli
       type: http

--- a/examples/single_task/slb/template/a10_slb_template_tcp.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_tcp.yaml
@@ -1,39 +1,30 @@
 
 
-- name: Create a10_slb_template_tcp example playbook
+- name: Create a10.acos_axapi.a10_slb_template_tcp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_tcp instance
-    a10_slb_template_tcp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_slb_template_tcp instance
+    a10.acos_axapi.a10_slb_template_tcp:
       name: default
       idle_timeout: 1
 
-- name: Update a10_slb_template_tcp example playbook
+- name: Update a10.acos_axapi.a10_slb_template_tcp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_tcp instance
-    a10_slb_template_tcp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_slb_template_tcp instance
+    a10.acos_axapi.a10_slb_template_tcp:
       state: present
       name: default
       idle_timeout: 1
 
-- name: Delete a10_slb_template_tcp example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_tcp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_tcp instance
-    a10_slb_template_tcp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_tcp instance
+    a10.acos_axapi.a10_slb_template_tcp:
       state: absent
       name: default
       idle_timeout: 1

--- a/examples/single_task/slb/template/a10_slb_template_tcp_create.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_tcp_create.yaml
@@ -1,13 +1,8 @@
-- name: Create a10_slb_template_tcp example playbook
+- name: Create a10.acos_axapi.a10_slb_template_tcp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_tcp instance
-    a10_slb_template_tcp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_slb_template_tcp instance
+    a10.acos_axapi.a10_slb_template_tcp:
       name: default
       idle_timeout: 1

--- a/examples/single_task/slb/template/a10_slb_template_tcp_delete.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_tcp_delete.yaml
@@ -1,14 +1,9 @@
-- name: Delete a10_slb_template_tcp example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_tcp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_tcp instance
-    a10_slb_template_tcp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_tcp instance
+    a10.acos_axapi.a10_slb_template_tcp:
       state: absent
       name: default
       idle_timeout: 1

--- a/examples/single_task/slb/template/a10_slb_template_tcp_proxy.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_tcp_proxy.yaml
@@ -1,14 +1,11 @@
 
 
-- name: Create a10_slb_template_tcp_proxy example playbook
+- name: Create a10.acos_axapi.a10_slb_template_tcp_proxy example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_tcp_proxy instance
-    a10_slb_template_tcp_proxy:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_slb_template_tcp_proxy instance
+    a10.acos_axapi.a10_slb_template_tcp_proxy:
       name: default
       ack_aggressiveness: low
       fin_timeout: 1
@@ -22,15 +19,12 @@
       timewait: 1
       invalid_rate_limit: 0
 
-- name: Update a10_slb_template_tcp_proxy example playbook
+- name: Update a10.acos_axapi.a10_slb_template_tcp_proxy example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_tcp_proxy instance
-    a10_slb_template_tcp_proxy:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_slb_template_tcp_proxy instance
+    a10.acos_axapi.a10_slb_template_tcp_proxy:
       state: present
       name: default
       ack_aggressiveness: low
@@ -45,15 +39,12 @@
       timewait: 1
       invalid_rate_limit: 0
 
-- name: Delete a10_slb_template_tcp_proxy example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_tcp_proxy example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_tcp_proxy instance
-    a10_slb_template_tcp_proxy:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_tcp_proxy instance
+    a10.acos_axapi.a10_slb_template_tcp_proxy:
       state: absent
       name: default
       ack_aggressiveness: low

--- a/examples/single_task/slb/template/a10_slb_template_tcp_proxy_create.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_tcp_proxy_create.yaml
@@ -1,14 +1,9 @@
-- name: Create a10_slb_template_tcp_proxy example playbook
+- name: Create a10.acos_axapi.a10_slb_template_tcp_proxy example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_tcp_proxy instance
-    a10_slb_template_tcp_proxy:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_slb_template_tcp_proxy instance
+    a10.acos_axapi.a10_slb_template_tcp_proxy:
       name: default
       ack_aggressiveness: low
       fin_timeout: 1

--- a/examples/single_task/slb/template/a10_slb_template_tcp_proxy_delete.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_tcp_proxy_delete.yaml
@@ -1,14 +1,9 @@
-- name: Delete a10_slb_template_tcp_proxy example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_tcp_proxy example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_tcp_proxy instance
-    a10_slb_template_tcp_proxy:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_tcp_proxy instance
+    a10.acos_axapi.a10_slb_template_tcp_proxy:
       state: absent
       name: default
       ack_aggressiveness: low

--- a/examples/single_task/slb/template/a10_slb_template_tcp_proxy_update.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_tcp_proxy_update.yaml
@@ -1,14 +1,9 @@
-- name: Update a10_slb_template_tcp_proxy example playbook
+- name: Update a10.acos_axapi.a10_slb_template_tcp_proxy example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_tcp_proxy instance
-    a10_slb_template_tcp_proxy:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Update a10.acos_axapi.a10_slb_template_tcp_proxy instance
+    a10.acos_axapi.a10_slb_template_tcp_proxy:
       state: present
       name: default
       ack_aggressiveness: low

--- a/examples/single_task/slb/template/a10_slb_template_tcp_update.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_tcp_update.yaml
@@ -1,14 +1,9 @@
-- name: Update a10_slb_template_tcp example playbook
+- name: Update a10.acos_axapi.a10_slb_template_tcp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_tcp instance
-    a10_slb_template_tcp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Update a10.acos_axapi.a10_slb_template_tcp instance
+    a10.acos_axapi.a10_slb_template_tcp:
       state: present
       name: default
       idle_timeout: 1

--- a/examples/single_task/slb/template/a10_slb_template_udp.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_udp.yaml
@@ -1,41 +1,32 @@
 
 
-- name: Create a10_slb_template_udp example playbook
+- name: Create a10.acos_axapi.a10_slb_template_udp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_udp instance
-    a10_slb_template_udp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_slb_template_udp instance
+    a10.acos_axapi.a10_slb_template_udp:
       name: default
       idle_timeout: 1
       stateless_conn_timeout: 5
 
-- name: Update a10_slb_template_udp example playbook
+- name: Update a10.acos_axapi.a10_slb_template_udp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_udp instance
-    a10_slb_template_udp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_slb_template_udp instance
+    a10.acos_axapi.a10_slb_template_udp:
       state: present
       name: default
       idle_timeout: 1
       stateless_conn_timeout: 5
 
-- name: Delete a10_slb_template_udp example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_udp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_udp instance
-    a10_slb_template_udp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_udp instance
+    a10.acos_axapi.a10_slb_template_udp:
       state: absent
       name: default
       idle_timeout: 1

--- a/examples/single_task/slb/template/a10_slb_template_udp_create.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_udp_create.yaml
@@ -1,14 +1,9 @@
-- name: Create a10_slb_template_udp example playbook
+- name: Create a10.acos_axapi.a10_slb_template_udp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_udp instance
-    a10_slb_template_udp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_slb_template_udp instance
+    a10.acos_axapi.a10_slb_template_udp:
       name: default
       idle_timeout: 1
       stateless_conn_timeout: 5

--- a/examples/single_task/slb/template/a10_slb_template_udp_delete.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_udp_delete.yaml
@@ -1,14 +1,9 @@
-- name: Delete a10_slb_template_udp example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_udp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_udp instance
-    a10_slb_template_udp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_udp instance
+    a10.acos_axapi.a10_slb_template_udp:
       state: absent
       name: default
       idle_timeout: 1

--- a/examples/single_task/slb/template/a10_slb_template_udp_update.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_udp_update.yaml
@@ -1,14 +1,9 @@
-- name: Update a10_slb_template_udp example playbook
+- name: Update a10.acos_axapi.a10_slb_template_udp example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_udp instance
-    a10_slb_template_udp:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Update a10.acos_axapi.a10_slb_template_udp instance
+    a10.acos_axapi.a10_slb_template_udp:
       state: present
       name: default
       idle_timeout: 1

--- a/examples/single_task/slb/template/a10_slb_template_virtual_port.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_virtual_port.yaml
@@ -1,43 +1,34 @@
 
 
-- name: Create a10_slb_template_virtual_port example playbook
+- name: Create a10.acos_axapi.a10_slb_template_virtual_port example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_virtual_port instance
-    a10_slb_template_virtual_port:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_slb_template_virtual_port instance
+    a10.acos_axapi.a10_slb_template_virtual_port:
       name: default
       conn_limit: 1
       rate_interval: second
       pkt_rate_interval: second
 
-- name: Update a10_slb_template_virtual_port example playbook
+- name: Update a10.acos_axapi.a10_slb_template_virtual_port example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_virtual_port instance
-    a10_slb_template_virtual_port:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_slb_template_virtual_port instance
+    a10.acos_axapi.a10_slb_template_virtual_port:
       state: present
       name: default
       conn_limit: 1
       rate_interval: second
       pkt_rate_interval: second
 
-- name: Delete a10_slb_template_virtual_port example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_virtual_port example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_virtual_port instance
-    a10_slb_template_virtual_port:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_virtual_port instance
+    a10.acos_axapi.a10_slb_template_virtual_port:
       state: absent
       name: default
       conn_limit: 1

--- a/examples/single_task/slb/template/a10_slb_template_virtual_port_create.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_virtual_port_create.yaml
@@ -1,13 +1,8 @@
-- name: Create a10_slb_template_virtual_port example playbook
+- name: Create a10.acos_axapi.a10_slb_template_virtual_port example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_virtual_port instance
-    a10_slb_template_virtual_port:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_slb_template_virtual_port instance
+    a10.acos_axapi.a10_slb_template_virtual_port:
       name: default
       conn_limit: 1

--- a/examples/single_task/slb/template/a10_slb_template_virtual_port_delete.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_virtual_port_delete.yaml
@@ -1,13 +1,8 @@
-- name: Delete a10_slb_template_virtual_port example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_virtual_port example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_virtual_port instance
-    a10_slb_template_virtual_port:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_virtual_port instance
+    a10.acos_axapi.a10_slb_template_virtual_port:
       state: absent
       name: default

--- a/examples/single_task/slb/template/a10_slb_template_virtual_port_update.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_virtual_port_update.yaml
@@ -1,14 +1,9 @@
-- name: Update a10_slb_template_virtual_port example playbook
+- name: Update a10.acos_axapi.a10_slb_template_virtual_port example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_virtual_port instance
-    a10_slb_template_virtual_port:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Update a10.acos_axapi.a10_slb_template_virtual_port instance
+    a10.acos_axapi.a10_slb_template_virtual_port:
       state: present
       name: default
       conn_limit: 1

--- a/examples/single_task/slb/template/a10_slb_template_virtual_server.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_virtual_server.yaml
@@ -1,29 +1,23 @@
 
 
-- name: Create a10_slb_template_virtual_server example playbook
+- name: Create a10.acos_axapi.a10_slb_template_virtual_server example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_virtual_server instance
-    a10_slb_template_virtual_server:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_slb_template_virtual_server instance
+    a10.acos_axapi.a10_slb_template_virtual_server:
       name: default
       conn_limit: 1
       rate_interval: second
       tcp_stack_tfo_cookie_time_limit: 1
       tcp_stack_tfo_backoff_time: 1
 
-- name: Update a10_slb_template_virtual_server example playbook
+- name: Update a10.acos_axapi.a10_slb_template_virtual_server example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_virtual_server instance
-    a10_slb_template_virtual_server:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_slb_template_virtual_server instance
+    a10.acos_axapi.a10_slb_template_virtual_server:
       state: present
       name: default
       conn_limit: 1
@@ -31,15 +25,12 @@
       tcp_stack_tfo_cookie_time_limit: 1
       tcp_stack_tfo_backoff_time: 1
 
-- name: Delete a10_slb_template_virtual_server example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_virtual_server example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_virtual_server instance
-    a10_slb_template_virtual_server:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_virtual_server instance
+    a10.acos_axapi.a10_slb_template_virtual_server:
       state: absent
       name: default
       conn_limit: 1

--- a/examples/single_task/slb/template/a10_slb_template_virtual_server_create.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_virtual_server_create.yaml
@@ -1,13 +1,8 @@
-- name: Create a10_slb_template_virtual_server example playbook
+- name: Create a10.acos_axapi.a10_slb_template_virtual_server example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_template_virtual_server instance
-    a10_slb_template_virtual_server:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_slb_template_virtual_server instance
+    a10.acos_axapi.a10_slb_template_virtual_server:
       name: default
       conn_limit: 1

--- a/examples/single_task/slb/template/a10_slb_template_virtual_server_delete.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_virtual_server_delete.yaml
@@ -1,14 +1,9 @@
-- name: Delete a10_slb_template_virtual_server example playbook
+- name: Delete a10.acos_axapi.a10_slb_template_virtual_server example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_template_virtual_server instance
-    a10_slb_template_virtual_server:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Delete a10.acos_axapi.a10_slb_template_virtual_server instance
+    a10.acos_axapi.a10_slb_template_virtual_server:
       state: absent
       name: default
       conn_limit: 1

--- a/examples/single_task/slb/template/a10_slb_template_virtual_server_update.yaml
+++ b/examples/single_task/slb/template/a10_slb_template_virtual_server_update.yaml
@@ -1,14 +1,9 @@
-- name: Update a10_slb_template_virtual_server example playbook
+- name: Update a10.acos_axapi.a10_slb_template_virtual_server example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_template_virtual_server instance
-    a10_slb_template_virtual_server:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Update a10.acos_axapi.a10_slb_template_virtual_server instance
+    a10.acos_axapi.a10_slb_template_virtual_server:
       state: present
       name: default
       conn_limit: 1

--- a/examples/single_task/slb/virtual_port/a10_slb_virtual_server_port_create.yaml
+++ b/examples/single_task/slb/virtual_port/a10_slb_virtual_server_port_create.yaml
@@ -1,14 +1,9 @@
-- name: Create a10_slb_virtual_server_port example playbook
+- name: Create a10.acos_axapi.a10_slb_virtual_server_port example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_virtual_server_port instance
-    a10_slb_virtual_server_port:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_slb_virtual_server_port instance
+    a10.acos_axapi.a10_slb_virtual_server_port:
       port_number: 8080
       protocol: tcp
       conn_limit: 1

--- a/examples/single_task/slb/virtual_port/a10_slb_virtual_server_port_delete.yaml
+++ b/examples/single_task/slb/virtual_port/a10_slb_virtual_server_port_delete.yaml
@@ -1,14 +1,9 @@
-- name: Delete a10_slb_virtual_server_port example playbook
+- name: Delete a10.acos_axapi.a10_slb_virtual_server_port example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_virtual_server_port instance
-    a10_slb_virtual_server_port:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Delete a10.acos_axapi.a10_slb_virtual_server_port instance
+    a10.acos_axapi.a10_slb_virtual_server_port:
       state: absent
       port_number: 0
       protocol: tcp

--- a/examples/single_task/slb/virtual_port/a10_slb_virtual_server_port_update.yaml
+++ b/examples/single_task/slb/virtual_port/a10_slb_virtual_server_port_update.yaml
@@ -1,14 +1,9 @@
-- name: Update a10_slb_virtual_server_port example playbook
+- name: Update a10.acos_axapi.a10_slb_virtual_server_port example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_virtual_server_port instance
-    a10_slb_virtual_server_port:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Update a10.acos_axapi.a10_slb_virtual_server_port instance
+    a10.acos_axapi.a10_slb_virtual_server_port:
       state: present
       port_number: 8080
       protocol: tcp

--- a/examples/single_task/slb/virtual_server/a10_slb_virtual_server_create.yaml
+++ b/examples/single_task/slb/virtual_server/a10_slb_virtual_server_create.yaml
@@ -1,14 +1,9 @@
-- name: Create a10_slb_virtual_server example playbook
+- name: Create a10.acos_axapi.a10_slb_virtual_server example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_slb_virtual_server instance
-    a10_slb_virtual_server:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_slb_virtual_server instance
+    a10.acos_axapi.a10_slb_virtual_server:
       state: present
       name: vs1
       ip_address: 10.10.0.1

--- a/examples/single_task/slb/virtual_server/a10_slb_virtual_server_delete.yaml
+++ b/examples/single_task/slb/virtual_server/a10_slb_virtual_server_delete.yaml
@@ -1,14 +1,9 @@
-- name: Delete a10_slb_virtual_server example playbook
+- name: Delete a10.acos_axapi.a10_slb_virtual_server example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_slb_virtual_server instance
-    a10_slb_virtual_server:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Delete a10.acos_axapi.a10_slb_virtual_server instance
+    a10.acos_axapi.a10_slb_virtual_server:
       state: absent
       name: vs1
       ip_address: 10.10.0.1

--- a/examples/single_task/slb/virtual_server/a10_slb_virtual_server_update.yaml
+++ b/examples/single_task/slb/virtual_server/a10_slb_virtual_server_update.yaml
@@ -1,14 +1,9 @@
-- name: Update a10_slb_virtual_server example playbook
+- name: Update a10.acos_axapi.a10_slb_virtual_server example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_slb_virtual_server instance
-    a10_slb_virtual_server:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Update a10.acos_axapi.a10_slb_virtual_server instance
+    a10.acos_axapi.a10_slb_virtual_server:
       state: present
       name: vs1
       ip_address: 10.10.0.1

--- a/examples/single_task/techsupport/a10_delete_showtech_file.py
+++ b/examples/single_task/techsupport/a10_delete_showtech_file.py
@@ -1,12 +1,7 @@
-- name: Delete a10_Generates Show Tech file example playbook
+- name: Delete a10.acos_axapi.a10_Generates Show Tech file example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_Generates Show Tech file instance
-    a10_generates_show_tech_file:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Delete a10.acos_axapi.a10_Generates Show Tech file instance
+    a10.acos_axapi.a10_generates_show_tech_file:
       state: absent

--- a/examples/single_task/techsupport/a10_generate_showtech_file.py
+++ b/examples/single_task/techsupport/a10_generate_showtech_file.py
@@ -1,12 +1,7 @@
 
-- name: Create a10_Generates Show Tech file example playbook
+- name: Create a10.acos_axapi.a10_Generates Show Tech file example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_Generates Show Tech file instance
-    a10_generates_show_tech_file:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: Create a10.acos_axapi.a10_Generates Show Tech file instance
+    a10.acos_axapi.a10_generates_show_tech_file:

--- a/examples/single_task/timezone/a10_timezone.yml
+++ b/examples/single_task/timezone/a10_timezone.yml
@@ -1,14 +1,9 @@
 - name: Set timezone settings example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: a10_timezone settings 
-    a10_timezone:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_timezone settings 
+    a10.acos_axapi.a10_timezone:
       timezone_index_cfg: 
         timezone-index : "Asia/Calcutta"
         nodst : true

--- a/examples/single_task/vrrp_a/a10_vrrp_a_fail_over_policy_template.yaml
+++ b/examples/single_task/vrrp_a/a10_vrrp_a_fail_over_policy_template.yaml
@@ -1,36 +1,27 @@
 
 
-- name: Create a10_vrrp_a_fail_over_policy_template example playbook
+- name: Create a10.acos_axapi.a10_vrrp_a_fail_over_policy_template example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_vrrp_a_fail_over_policy_template instance
-    a10_vrrp_a_fail_over_policy_template:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_vrrp_a_fail_over_policy_template instance
+    a10.acos_axapi.a10_vrrp_a_fail_over_policy_template:
       name: my_fail-over-policy-template
 
-- name: Update a10_vrrp_a_fail_over_policy_template example playbook
+- name: Update a10.acos_axapi.a10_vrrp_a_fail_over_policy_template example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_vrrp_a_fail_over_policy_template instance
-    a10_vrrp_a_fail_over_policy_template:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_vrrp_a_fail_over_policy_template instance
+    a10.acos_axapi.a10_vrrp_a_fail_over_policy_template:
       state: present
       name: my_fail-over-policy-template
 
-- name: Delete a10_vrrp_a_fail_over_policy_template example playbook
+- name: Delete a10.acos_axapi.a10_vrrp_a_fail_over_policy_template example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_vrrp_a_fail_over_policy_template instance
-    a10_vrrp_a_fail_over_policy_template:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_vrrp_a_fail_over_policy_template instance
+    a10.acos_axapi.a10_vrrp_a_fail_over_policy_template:
       state: absent
       name: my_fail-over-policy-template

--- a/examples/single_task/vrrp_a/a10_vrrp_a_fail_over_policy_template.yml
+++ b/examples/single_task/vrrp_a/a10_vrrp_a_fail_over_policy_template.yml
@@ -1,14 +1,9 @@
-- name: a10_vrrp_a_fail_over_policy_template example playbook
+- name: a10.acos_axapi.a10_vrrp_a_fail_over_policy_template example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: a10_vrrp_a_fail_over_policy_template
-    a10_vrrp_a_fail_over_policy_template:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}"
+  - name: a10.acos_axapi.a10_vrrp_a_fail_over_policy_template
+    a10.acos_axapi.a10_vrrp_a_fail_over_policy_template:
       vlan_cfg:
         - vlan: 1
           timeout: "200"

--- a/examples/single_task/vrrp_a/a10_vrrp_a_force_self_standby_persistent.yaml
+++ b/examples/single_task/vrrp_a/a10_vrrp_a_force_self_standby_persistent.yaml
@@ -1,36 +1,27 @@
 
 
-- name: Create a10_vrrp_a_force_self_standby_persistent example playbook
+- name: Create a10.acos_axapi.a10_vrrp_a_force_self_standby_persistent example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_vrrp_a_force_self_standby_persistent instance
-    a10_vrrp_a_force_self_standby_persistent:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_vrrp_a_force_self_standby_persistent instance
+    a10.acos_axapi.a10_vrrp_a_force_self_standby_persistent:
       vrid: 0
 
-- name: Update a10_vrrp_a_force_self_standby_persistent example playbook
+- name: Update a10.acos_axapi.a10_vrrp_a_force_self_standby_persistent example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_vrrp_a_force_self_standby_persistent instance
-    a10_vrrp_a_force_self_standby_persistent:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_vrrp_a_force_self_standby_persistent instance
+    a10.acos_axapi.a10_vrrp_a_force_self_standby_persistent:
       state: present
       vrid: 0
 
-- name: Delete a10_vrrp_a_force_self_standby_persistent example playbook
+- name: Delete a10.acos_axapi.a10_vrrp_a_force_self_standby_persistent example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_vrrp_a_force_self_standby_persistent instance
-    a10_vrrp_a_force_self_standby_persistent:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_vrrp_a_force_self_standby_persistent instance
+    a10.acos_axapi.a10_vrrp_a_force_self_standby_persistent:
       state: absent
       vrid: 0

--- a/examples/single_task/vrrp_a/a10_vrrp_a_interface_ethernet.yaml
+++ b/examples/single_task/vrrp_a/a10_vrrp_a_interface_ethernet.yaml
@@ -1,36 +1,27 @@
 
 
-- name: Create a10_vrrp_a_interface_ethernet example playbook
+- name: Create a10.acos_axapi.a10_vrrp_a_interface_ethernet example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_vrrp_a_interface_ethernet instance
-    a10_vrrp_a_interface_ethernet:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_vrrp_a_interface_ethernet instance
+    a10.acos_axapi.a10_vrrp_a_interface_ethernet:
       ethernet_val: None
 
-- name: Update a10_vrrp_a_interface_ethernet example playbook
+- name: Update a10.acos_axapi.a10_vrrp_a_interface_ethernet example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_vrrp_a_interface_ethernet instance
-    a10_vrrp_a_interface_ethernet:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_vrrp_a_interface_ethernet instance
+    a10.acos_axapi.a10_vrrp_a_interface_ethernet:
       state: present
       ethernet_val: None
 
-- name: Delete a10_vrrp_a_interface_ethernet example playbook
+- name: Delete a10.acos_axapi.a10_vrrp_a_interface_ethernet example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_vrrp_a_interface_ethernet instance
-    a10_vrrp_a_interface_ethernet:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_vrrp_a_interface_ethernet instance
+    a10.acos_axapi.a10_vrrp_a_interface_ethernet:
       state: absent
       ethernet_val: None

--- a/examples/single_task/vrrp_a/a10_vrrp_a_interface_trunk.yaml
+++ b/examples/single_task/vrrp_a/a10_vrrp_a_interface_trunk.yaml
@@ -1,36 +1,27 @@
 
 
-- name: Create a10_vrrp_a_interface_trunk example playbook
+- name: Create a10.acos_axapi.a10_vrrp_a_interface_trunk example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_vrrp_a_interface_trunk instance
-    a10_vrrp_a_interface_trunk:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_vrrp_a_interface_trunk instance
+    a10.acos_axapi.a10_vrrp_a_interface_trunk:
       trunk_val: 1
 
-- name: Update a10_vrrp_a_interface_trunk example playbook
+- name: Update a10.acos_axapi.a10_vrrp_a_interface_trunk example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_vrrp_a_interface_trunk instance
-    a10_vrrp_a_interface_trunk:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_vrrp_a_interface_trunk instance
+    a10.acos_axapi.a10_vrrp_a_interface_trunk:
       state: present
       trunk_val: 1
 
-- name: Delete a10_vrrp_a_interface_trunk example playbook
+- name: Delete a10.acos_axapi.a10_vrrp_a_interface_trunk example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_vrrp_a_interface_trunk instance
-    a10_vrrp_a_interface_trunk:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_vrrp_a_interface_trunk instance
+    a10.acos_axapi.a10_vrrp_a_interface_trunk:
       state: absent
       trunk_val: 1

--- a/examples/single_task/vrrp_a/a10_vrrp_a_l2_inline_peer_ip.yaml
+++ b/examples/single_task/vrrp_a/a10_vrrp_a_l2_inline_peer_ip.yaml
@@ -1,36 +1,27 @@
 
 
-- name: Create a10_vrrp_a_l2_inline_peer_ip example playbook
+- name: Create a10.acos_axapi.a10_vrrp_a_l2_inline_peer_ip example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_vrrp_a_l2_inline_peer_ip instance
-    a10_vrrp_a_l2_inline_peer_ip:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_vrrp_a_l2_inline_peer_ip instance
+    a10.acos_axapi.a10_vrrp_a_l2_inline_peer_ip:
       ip_address: 10.0.0.1
 
-- name: Update a10_vrrp_a_l2_inline_peer_ip example playbook
+- name: Update a10.acos_axapi.a10_vrrp_a_l2_inline_peer_ip example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_vrrp_a_l2_inline_peer_ip instance
-    a10_vrrp_a_l2_inline_peer_ip:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_vrrp_a_l2_inline_peer_ip instance
+    a10.acos_axapi.a10_vrrp_a_l2_inline_peer_ip:
       state: present
       ip_address: 10.0.0.1
 
-- name: Delete a10_vrrp_a_l2_inline_peer_ip example playbook
+- name: Delete a10.acos_axapi.a10_vrrp_a_l2_inline_peer_ip example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_vrrp_a_l2_inline_peer_ip instance
-    a10_vrrp_a_l2_inline_peer_ip:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_vrrp_a_l2_inline_peer_ip instance
+    a10.acos_axapi.a10_vrrp_a_l2_inline_peer_ip:
       state: absent
       ip_address: 10.0.0.1

--- a/examples/single_task/vrrp_a/a10_vrrp_a_ospf_inline.yaml
+++ b/examples/single_task/vrrp_a/a10_vrrp_a_ospf_inline.yaml
@@ -1,36 +1,27 @@
 
 
-- name: Create a10_vrrp_a_ospf_inline example playbook
+- name: Create a10.acos_axapi.a10_vrrp_a_ospf_inline example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_vrrp_a_ospf_inline instance
-    a10_vrrp_a_ospf_inline:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_vrrp_a_ospf_inline instance
+    a10.acos_axapi.a10_vrrp_a_ospf_inline:
       vlan: 1
 
-- name: Update a10_vrrp_a_ospf_inline example playbook
+- name: Update a10.acos_axapi.a10_vrrp_a_ospf_inline example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_vrrp_a_ospf_inline instance
-    a10_vrrp_a_ospf_inline:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_vrrp_a_ospf_inline instance
+    a10.acos_axapi.a10_vrrp_a_ospf_inline:
       state: present
       vlan: 1
 
-- name: Delete a10_vrrp_a_ospf_inline example playbook
+- name: Delete a10.acos_axapi.a10_vrrp_a_ospf_inline example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_vrrp_a_ospf_inline instance
-    a10_vrrp_a_ospf_inline:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_vrrp_a_ospf_inline instance
+    a10.acos_axapi.a10_vrrp_a_ospf_inline:
       state: absent
       vlan: 1

--- a/examples/single_task/vrrp_a/a10_vrrp_a_preferred_session_sync_port_ethernet.yaml
+++ b/examples/single_task/vrrp_a/a10_vrrp_a_preferred_session_sync_port_ethernet.yaml
@@ -1,36 +1,27 @@
 
 
-- name: Create a10_vrrp_a_preferred_session_sync_port_ethernet example playbook
+- name: Create a10.acos_axapi.a10_vrrp_a_preferred_session_sync_port_ethernet example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_vrrp_a_preferred_session_sync_port_ethernet instance
-    a10_vrrp_a_preferred_session_sync_port_ethernet:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_vrrp_a_preferred_session_sync_port_ethernet instance
+    a10.acos_axapi.a10_vrrp_a_preferred_session_sync_port_ethernet:
       pre_eth: None
 
-- name: Update a10_vrrp_a_preferred_session_sync_port_ethernet example playbook
+- name: Update a10.acos_axapi.a10_vrrp_a_preferred_session_sync_port_ethernet example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_vrrp_a_preferred_session_sync_port_ethernet instance
-    a10_vrrp_a_preferred_session_sync_port_ethernet:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_vrrp_a_preferred_session_sync_port_ethernet instance
+    a10.acos_axapi.a10_vrrp_a_preferred_session_sync_port_ethernet:
       state: present
       pre_eth: None
 
-- name: Delete a10_vrrp_a_preferred_session_sync_port_ethernet example playbook
+- name: Delete a10.acos_axapi.a10_vrrp_a_preferred_session_sync_port_ethernet example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_vrrp_a_preferred_session_sync_port_ethernet instance
-    a10_vrrp_a_preferred_session_sync_port_ethernet:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_vrrp_a_preferred_session_sync_port_ethernet instance
+    a10.acos_axapi.a10_vrrp_a_preferred_session_sync_port_ethernet:
       state: absent
       pre_eth: None

--- a/examples/single_task/vrrp_a/a10_vrrp_a_preferred_session_sync_port_trunk.yaml
+++ b/examples/single_task/vrrp_a/a10_vrrp_a_preferred_session_sync_port_trunk.yaml
@@ -1,36 +1,27 @@
 
 
-- name: Create a10_vrrp_a_preferred_session_sync_port_trunk example playbook
+- name: Create a10.acos_axapi.a10_vrrp_a_preferred_session_sync_port_trunk example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_vrrp_a_preferred_session_sync_port_trunk instance
-    a10_vrrp_a_preferred_session_sync_port_trunk:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_vrrp_a_preferred_session_sync_port_trunk instance
+    a10.acos_axapi.a10_vrrp_a_preferred_session_sync_port_trunk:
       pre_trunk: 1
 
-- name: Update a10_vrrp_a_preferred_session_sync_port_trunk example playbook
+- name: Update a10.acos_axapi.a10_vrrp_a_preferred_session_sync_port_trunk example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_vrrp_a_preferred_session_sync_port_trunk instance
-    a10_vrrp_a_preferred_session_sync_port_trunk:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_vrrp_a_preferred_session_sync_port_trunk instance
+    a10.acos_axapi.a10_vrrp_a_preferred_session_sync_port_trunk:
       state: present
       pre_trunk: 1
 
-- name: Delete a10_vrrp_a_preferred_session_sync_port_trunk example playbook
+- name: Delete a10.acos_axapi.a10_vrrp_a_preferred_session_sync_port_trunk example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_vrrp_a_preferred_session_sync_port_trunk instance
-    a10_vrrp_a_preferred_session_sync_port_trunk:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_vrrp_a_preferred_session_sync_port_trunk instance
+    a10.acos_axapi.a10_vrrp_a_preferred_session_sync_port_trunk:
       state: absent
       pre_trunk: 1

--- a/examples/single_task/vrrp_a/a10_vrrp_a_restart_port_list_vrid.yaml
+++ b/examples/single_task/vrrp_a/a10_vrrp_a_restart_port_list_vrid.yaml
@@ -1,36 +1,27 @@
 
 
-- name: Create a10_vrrp_a_restart_port_list_vrid example playbook
+- name: Create a10.acos_axapi.a10_vrrp_a_restart_port_list_vrid example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_vrrp_a_restart_port_list_vrid instance
-    a10_vrrp_a_restart_port_list_vrid:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_vrrp_a_restart_port_list_vrid instance
+    a10.acos_axapi.a10_vrrp_a_restart_port_list_vrid:
       vrid_val: 0
 
-- name: Update a10_vrrp_a_restart_port_list_vrid example playbook
+- name: Update a10.acos_axapi.a10_vrrp_a_restart_port_list_vrid example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_vrrp_a_restart_port_list_vrid instance
-    a10_vrrp_a_restart_port_list_vrid:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_vrrp_a_restart_port_list_vrid instance
+    a10.acos_axapi.a10_vrrp_a_restart_port_list_vrid:
       state: present
       vrid_val: 0
 
-- name: Delete a10_vrrp_a_restart_port_list_vrid example playbook
+- name: Delete a10.acos_axapi.a10_vrrp_a_restart_port_list_vrid example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_vrrp_a_restart_port_list_vrid instance
-    a10_vrrp_a_restart_port_list_vrid:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_vrrp_a_restart_port_list_vrid instance
+    a10.acos_axapi.a10_vrrp_a_restart_port_list_vrid:
       state: absent
       vrid_val: 0

--- a/examples/single_task/vrrp_a/a10_vrrp_a_vrid.yaml
+++ b/examples/single_task/vrrp_a/a10_vrrp_a_vrid.yaml
@@ -1,36 +1,27 @@
 
 
-- name: Create a10_vrrp_a_vrid example playbook
+- name: Create a10.acos_axapi.a10_vrrp_a_vrid example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_vrrp_a_vrid instance
-    a10_vrrp_a_vrid:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_vrrp_a_vrid instance
+    a10.acos_axapi.a10_vrrp_a_vrid:
       vrid_val: 0
 
-- name: Update a10_vrrp_a_vrid example playbook
+- name: Update a10.acos_axapi.a10_vrrp_a_vrid example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_vrrp_a_vrid instance
-    a10_vrrp_a_vrid:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_vrrp_a_vrid instance
+    a10.acos_axapi.a10_vrrp_a_vrid:
       state: present
       vrid_val: 0
 
-- name: Delete a10_vrrp_a_vrid example playbook
+- name: Delete a10.acos_axapi.a10_vrrp_a_vrid example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_vrrp_a_vrid instance
-    a10_vrrp_a_vrid:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_vrrp_a_vrid instance
+    a10.acos_axapi.a10_vrrp_a_vrid:
       state: absent
       vrid_val: 0

--- a/examples/single_task/vrrp_a/a10_vrrp_a_vrid_blade_parameters_tracking_options_gateway_ipv4_gateway.yaml
+++ b/examples/single_task/vrrp_a/a10_vrrp_a_vrid_blade_parameters_tracking_options_gateway_ipv4_gateway.yaml
@@ -1,36 +1,27 @@
 
 
-- name: Create a10_vrrp_a_vrid_blade_parameters_tracking_options_gateway_ipv4_gateway example playbook
+- name: Create a10.acos_axapi.a10_vrrp_a_vrid_blade_parameters_tracking_options_gateway_ipv4_gateway example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_vrrp_a_vrid_blade_parameters_tracking_options_gateway_ipv4_gateway instance
-    a10_vrrp_a_vrid_blade_parameters_tracking_options_gateway_ipv4_gateway:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_vrrp_a_vrid_blade_parameters_tracking_options_gateway_ipv4_gateway instance
+    a10.acos_axapi.a10_vrrp_a_vrid_blade_parameters_tracking_options_gateway_ipv4_gateway:
       ip_address: 10.0.0.1
 
-- name: Update a10_vrrp_a_vrid_blade_parameters_tracking_options_gateway_ipv4_gateway example playbook
+- name: Update a10.acos_axapi.a10_vrrp_a_vrid_blade_parameters_tracking_options_gateway_ipv4_gateway example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_vrrp_a_vrid_blade_parameters_tracking_options_gateway_ipv4_gateway instance
-    a10_vrrp_a_vrid_blade_parameters_tracking_options_gateway_ipv4_gateway:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_vrrp_a_vrid_blade_parameters_tracking_options_gateway_ipv4_gateway instance
+    a10.acos_axapi.a10_vrrp_a_vrid_blade_parameters_tracking_options_gateway_ipv4_gateway:
       state: present
       ip_address: 10.0.0.1
 
-- name: Delete a10_vrrp_a_vrid_blade_parameters_tracking_options_gateway_ipv4_gateway example playbook
+- name: Delete a10.acos_axapi.a10_vrrp_a_vrid_blade_parameters_tracking_options_gateway_ipv4_gateway example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_vrrp_a_vrid_blade_parameters_tracking_options_gateway_ipv4_gateway instance
-    a10_vrrp_a_vrid_blade_parameters_tracking_options_gateway_ipv4_gateway:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_vrrp_a_vrid_blade_parameters_tracking_options_gateway_ipv4_gateway instance
+    a10.acos_axapi.a10_vrrp_a_vrid_blade_parameters_tracking_options_gateway_ipv4_gateway:
       state: absent
       ip_address: 10.0.0.1

--- a/examples/single_task/vrrp_a/a10_vrrp_a_vrid_blade_parameters_tracking_options_gateway_ipv6_gateway.yaml
+++ b/examples/single_task/vrrp_a/a10_vrrp_a_vrid_blade_parameters_tracking_options_gateway_ipv6_gateway.yaml
@@ -1,36 +1,27 @@
 
 
-- name: Create a10_vrrp_a_vrid_blade_parameters_tracking_options_gateway_ipv6_gateway example playbook
+- name: Create a10.acos_axapi.a10_vrrp_a_vrid_blade_parameters_tracking_options_gateway_ipv6_gateway example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_vrrp_a_vrid_blade_parameters_tracking_options_gateway_ipv6_gateway instance
-    a10_vrrp_a_vrid_blade_parameters_tracking_options_gateway_ipv6_gateway:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_vrrp_a_vrid_blade_parameters_tracking_options_gateway_ipv6_gateway instance
+    a10.acos_axapi.a10_vrrp_a_vrid_blade_parameters_tracking_options_gateway_ipv6_gateway:
       ipv6_address: NO_EXAMPLE
 
-- name: Update a10_vrrp_a_vrid_blade_parameters_tracking_options_gateway_ipv6_gateway example playbook
+- name: Update a10.acos_axapi.a10_vrrp_a_vrid_blade_parameters_tracking_options_gateway_ipv6_gateway example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_vrrp_a_vrid_blade_parameters_tracking_options_gateway_ipv6_gateway instance
-    a10_vrrp_a_vrid_blade_parameters_tracking_options_gateway_ipv6_gateway:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_vrrp_a_vrid_blade_parameters_tracking_options_gateway_ipv6_gateway instance
+    a10.acos_axapi.a10_vrrp_a_vrid_blade_parameters_tracking_options_gateway_ipv6_gateway:
       state: present
       ipv6_address: NO_EXAMPLE
 
-- name: Delete a10_vrrp_a_vrid_blade_parameters_tracking_options_gateway_ipv6_gateway example playbook
+- name: Delete a10.acos_axapi.a10_vrrp_a_vrid_blade_parameters_tracking_options_gateway_ipv6_gateway example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_vrrp_a_vrid_blade_parameters_tracking_options_gateway_ipv6_gateway instance
-    a10_vrrp_a_vrid_blade_parameters_tracking_options_gateway_ipv6_gateway:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_vrrp_a_vrid_blade_parameters_tracking_options_gateway_ipv6_gateway instance
+    a10.acos_axapi.a10_vrrp_a_vrid_blade_parameters_tracking_options_gateway_ipv6_gateway:
       state: absent
       ipv6_address: NO_EXAMPLE

--- a/examples/single_task/vrrp_a/a10_vrrp_a_vrid_lead.yaml
+++ b/examples/single_task/vrrp_a/a10_vrrp_a_vrid_lead.yaml
@@ -1,36 +1,27 @@
 
 
-- name: Create a10_vrrp_a_vrid_lead example playbook
+- name: Create a10.acos_axapi.a10_vrrp_a_vrid_lead example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Create a10_vrrp_a_vrid_lead instance
-    a10_vrrp_a_vrid_lead:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Create a10.acos_axapi.a10_vrrp_a_vrid_lead instance
+    a10.acos_axapi.a10_vrrp_a_vrid_lead:
       vrid_lead_str: default-vrid-lead
 
-- name: Update a10_vrrp_a_vrid_lead example playbook
+- name: Update a10.acos_axapi.a10_vrrp_a_vrid_lead example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Update a10_vrrp_a_vrid_lead instance
-    a10_vrrp_a_vrid_lead:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Update a10.acos_axapi.a10_vrrp_a_vrid_lead instance
+    a10.acos_axapi.a10_vrrp_a_vrid_lead:
       state: present
       vrid_lead_str: default-vrid-lead
 
-- name: Delete a10_vrrp_a_vrid_lead example playbook
+- name: Delete a10.acos_axapi.a10_vrrp_a_vrid_lead example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: Delete a10_vrrp_a_vrid_lead instance
-    a10_vrrp_a_vrid_lead:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
+  - name: Delete a10.acos_axapi.a10_vrrp_a_vrid_lead instance
+    a10.acos_axapi.a10_vrrp_a_vrid_lead:
       state: absent
       vrid_lead_str: default-vrid-lead

--- a/examples/single_task/write/memory/a10_write_memory.yml
+++ b/examples/single_task/write/memory/a10_write_memory.yml
@@ -1,13 +1,8 @@
 - name: Save Configuration (Write Memory) example playbook
   connection: local
-  hosts: localhost
+  hosts: "{{desired_inventory_group}}"
   tasks:
-  - name: a10_write_memory instance
-    a10_write_memory:
-      a10_host: "{{ a10_host }}"
-      a10_username: "{{ a10_username }}"
-      a10_password: "{{ a10_password }}"
-      a10_port: "{{ a10_port }}"
-      a10_protocol: "{{ a10_protocol }}}"
+  - name: a10.acos_axapi.a10_write_memory instance
+    a10.acos_axapi.a10_write_memory:
       partition: "shared"
       destination: "primary"


### PR DESCRIPTION
- Updated the action names to collection format FQCN i.e `a10.acos_axapi.module_name`.

- Removed `a10_host`, `a10_username`, `a10_password`, `a10_port` and `a10_protocol` parameters as we can support Inventory now.


**Closes**:
ANS-83