### PR TITLE
ANS-144: Resolved an issue of ansible-doc failure occurring for some modules.

### DIFF
--- a/plugins/modules/a10_ip_fib.py
+++ b/plugins/modules/a10_ip_fib.py
@@ -111,7 +111,7 @@ def get_default_argspec():
 def get_argspec():
     rv = get_default_argspec()
     rv.update(dict(
-        oper=dict(type='dict', Total=dict(type='int', ), Total Paths=dict(type='int', ), IPv4_fib=dict(type='list', Interface=dict(type='str', choices=['Management', 'ethernet', 'trunk']), Distance=dict(type='int', ), Prefix=dict(type='str', ), Nexthop=dict(type='str', ), PrefixLen=dict(type='int', ))),
+        oper=dict(type='dict', Total=dict(type='int', ), Total_Paths=dict(type='int', ), IPv4_fib=dict(type='list', Interface=dict(type='str', choices=['Management', 'ethernet', 'trunk']), Distance=dict(type='int', ), Prefix=dict(type='str', ), Nexthop=dict(type='str', ), PrefixLen=dict(type='int', ))),
         uuid=dict(type='str', )
     ))
    

--- a/plugins/modules/a10_ip_rib.py
+++ b/plugins/modules/a10_ip_rib.py
@@ -117,7 +117,7 @@ def get_default_argspec():
 def get_argspec():
     rv = get_default_argspec()
     rv.update(dict(
-        oper=dict(type='dict', Total=dict(type='int', ), Limit=dict(type='int', ), Description=dict(type='str', ), IPv4_routes=dict(type='list', Distance=dict(type='int', ), Metric=dict(type='int', ), Nexthop=dict(type='str', ), PrefixLen=dict(type='int', ), Subtype=dict(type='str', choices=['inter-area', 'nssa-type-1', 'nssa-type-2', 'external-type-1', 'external-type-2', 'level-1', 'level-2']), Prefix=dict(type='str', ), Interface=dict(type='str', ), Type=dict(type='str', choices=['kernel', 'connected', 'static', 'rip', 'ospf', 'bgp', 'isis', 'vip', 'selected-vip', 'ip-nat-list', 'ip-nat', 'floating-ip', 'a10'])), Total Paths=dict(type='int', )),
+        oper=dict(type='dict', Total=dict(type='int', ), Limit=dict(type='int', ), Description=dict(type='str', ), IPv4_routes=dict(type='list', Distance=dict(type='int', ), Metric=dict(type='int', ), Nexthop=dict(type='str', ), PrefixLen=dict(type='int', ), Subtype=dict(type='str', choices=['inter-area', 'nssa-type-1', 'nssa-type-2', 'external-type-1', 'external-type-2', 'level-1', 'level-2']), Prefix=dict(type='str', ), Interface=dict(type='str', ), Type=dict(type='str', choices=['kernel', 'connected', 'static', 'rip', 'ospf', 'bgp', 'isis', 'vip', 'selected-vip', 'ip-nat-list', 'ip-nat', 'floating-ip', 'a10'])), Total_Paths=dict(type='int', )),
         uuid=dict(type='str', )
     ))
    

--- a/plugins/modules/a10_ipv6_fib.py
+++ b/plugins/modules/a10_ipv6_fib.py
@@ -111,7 +111,7 @@ def get_default_argspec():
 def get_argspec():
     rv = get_default_argspec()
     rv.update(dict(
-        oper=dict(type='dict', Total=dict(type='int', ), Total Paths=dict(type='int', ), IPv6_fib=dict(type='list', Interface=dict(type='str', choices=['Management', 'ethernet', 'trunk']), Distance=dict(type='int', ), Prefix=dict(type='str', ), Nexthop=dict(type='str', ), PrefixLen=dict(type='int', ))),
+        oper=dict(type='dict', Total=dict(type='int', ), Total_Paths=dict(type='int', ), IPv6_fib=dict(type='list', Interface=dict(type='str', choices=['Management', 'ethernet', 'trunk']), Distance=dict(type='int', ), Prefix=dict(type='str', ), Nexthop=dict(type='str', ), PrefixLen=dict(type='int', ))),
         uuid=dict(type='str', )
     ))
    

--- a/plugins/modules/a10_ipv6_rib.py
+++ b/plugins/modules/a10_ipv6_rib.py
@@ -117,7 +117,7 @@ def get_default_argspec():
 def get_argspec():
     rv = get_default_argspec()
     rv.update(dict(
-        oper=dict(type='dict', IPv6_routes=dict(type='list', Distance=dict(type='int', ), Metric=dict(type='int', ), Nexthop=dict(type='str', ), PrefixLen=dict(type='int', ), Subtype=dict(type='str', choices=['inter-area', 'nssa-type-1', 'nssa-type-2', 'external-type-1', 'external-type-2', 'level-1', 'level-2']), Prefix=dict(type='str', ), Interface=dict(type='str', ), Type=dict(type='str', choices=['kernel', 'connected', 'static', 'rip', 'ospf', 'bgp', 'isis', 'vip', 'selected-vip', 'ip-nat-list', 'ip-nat', 'floating-ip', 'a10'])), Total=dict(type='int', ), Limit=dict(type='int', ), Description=dict(type='str', ), Total Paths=dict(type='int', )),
+        oper=dict(type='dict', IPv6_routes=dict(type='list', Distance=dict(type='int', ), Metric=dict(type='int', ), Nexthop=dict(type='str', ), PrefixLen=dict(type='int', ), Subtype=dict(type='str', choices=['inter-area', 'nssa-type-1', 'nssa-type-2', 'external-type-1', 'external-type-2', 'level-1', 'level-2']), Prefix=dict(type='str', ), Interface=dict(type='str', ), Type=dict(type='str', choices=['kernel', 'connected', 'static', 'rip', 'ospf', 'bgp', 'isis', 'vip', 'selected-vip', 'ip-nat-list', 'ip-nat', 'floating-ip', 'a10'])), Total=dict(type='int', ), Limit=dict(type='int', ), Description=dict(type='str', ), Total_Paths=dict(type='int', )),
         uuid=dict(type='str', )
     ))
    


### PR DESCRIPTION
Specifically the following modules were facing Ansible-doc failure:
`a10_ip_fib.py`, `a10_ip_rib.py`, `a10_ipv6_fib.py`, `a10_ipv6_rib.py`
These modules are having their arguments with space in between them like `Total Paths`. 
Due to this, ansible-doc for them was getting failed.
So, here that space is replaced by `_` like `Total_Paths` and resolved that failure.

**Closes:**
ANS-144