### PR TITLE
Removed retry loop for request

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: a10
 name: acos_axapi
-version: 1.2.7
+version: 1.2.8
 readme: README.md
 authors:
     - "opensource@a10networks.com"

--- a/plugins/module_utils/axapi_client.py
+++ b/plugins/module_utils/axapi_client.py
@@ -75,9 +75,9 @@ class HttpClient(object):
         else:
             return my_dict
 
-    def request_impl(self, method, api_url, params={}, headers=None,
-                     file_name=None, file_content=None, axapi_args=None,
-                     max_retries=None, timeout=None, **kwargs):
+    def request(self, method, api_url, params={}, headers=None,
+                file_name=None, file_content=None, axapi_args=None,
+                max_retries=None, timeout=None, **kwargs):
         LOG.debug("axapi_http: full url = %s", self.url_base + api_url)
         LOG.debug("axapi_http: %s url = %s", method, api_url)
         LOG.debug("axapi_http: params = %s", json.dumps(logutils.clean(params), indent=4))
@@ -167,32 +167,6 @@ class HttpClient(object):
             acos_responses.raise_axapi_auth_error(json_response, method, api_url, headers)
 
         return json_response, device_response.status_code
-
-    def request(self, method, api_url, params={}, headers=None,
-                file_name=None, file_content=None, axapi_args=None,
-                max_retries=None, timeout=None, **kwargs):
-        retry_timeout = 300
-        if timeout and timeout > retry_timeout:
-            retry_timeout = timeout
-        start_time = time.time()
-        loop = True
-
-        while loop:
-            try:
-                return self.request_impl(method, api_url, params, headers,
-                                         file_name=file_name, file_content=file_content,
-                                         max_retries=max_retries,
-                                         timeout=timeout, axapi_args=axapi_args,
-                                         **kwargs)
-
-            except acos_responses.axapi_retry_exceptions() as e:
-                LOG.warning("ACOS device system is busy: %s", str(e))
-                loop = ((time.time() - start_time) <= retry_timeout)
-                if not loop:
-                    raise e
-                time.sleep(1)
-            except (Exception) as e:
-                raise e
 
     def get(self, api_url, params={}, headers=None, max_retries=None, timeout=None, axapi_args=None, **kwargs):
         return self.request("GET", api_url, params, headers, max_retries=max_retries,


### PR DESCRIPTION
## Description
Remove loop for system busy. Ansible modules should fail immediately.

Severity Level: High


## Connected SDK generator PR (Optional)
Did not require SDK modification

## Technical Approach
- Removed retry logic from axapi client

## General Playbook Changes (Optional)
N/A

## Test Cases
N/A

## Manual Testing
N/A
