### PR TITLE
Allowed for special case when 'CREATE' method is not allowed

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: a10
 name: acos_axapi
-version: 1.2.8
+version: 1.2.10
 readme: README.md
 authors:
     - "opensource@a10networks.com"

--- a/plugins/modules/a10_interface_ethernet.py
+++ b/plugins/modules/a10_interface_ethernet.py
@@ -2456,11 +2456,7 @@ def present(module, result, existing_config):
     change_results = report_changes(module, result, existing_config, payload)
     if module.check_mode:
         return change_results
-    elif not existing_config:
-        return create(module, result, payload)
-    elif existing_config and change_results.get('changed'):
-        return update(module, result, existing_config, payload)
-    return result
+    return update(module, result, existing_config, payload)
 
 
 def delete(module, result):

--- a/plugins/modules/a10_vcs_vblades_stat.py
+++ b/plugins/modules/a10_vcs_vblades_stat.py
@@ -379,11 +379,7 @@ def present(module, result, existing_config):
     change_results = report_changes(module, result, existing_config, payload)
     if module.check_mode:
         return change_results
-    elif not existing_config:
-        return create(module, result, payload)
-    elif existing_config and change_results.get('changed'):
-        return update(module, result, existing_config, payload)
-    return result
+    return update(module, result, existing_config, payload)
 
 
 def run_command(module):


### PR DESCRIPTION
## Description
Allowed for special case when 'CREATE' method is not allowed

## Jira Ticket
N/A

## Connected SDK generator PR (Optional)
[*Note: This is a private repository*](https://github.com/a10networks/sdkgenerator/pull/109)

## Technical Approach
- Removed check on existing config as interface will report non-existence even when it does

## General Playbook Changes (Optional)
N/A

## Test Cases
N/A

## Manual Testing
Playbook used to test:
```
- name: File import example
  connection: local
  hosts: vthunder
  tasks:
  - name: Create partition
    a10.acos_axapi.a10_partition:
      partition_name: new_partition
      id: 6

  - name: Upload cert task
    a10.acos_axapi.a10_interface_ethernet:
      ifnum: 2
      action: enable
      a10_partition: new_partition
```
