### PR TITLE
Fixing issue with changing active-partition

### DIFF
--- a/plugins/module_utils/client.py
+++ b/plugins/module_utils/client.py
@@ -74,7 +74,7 @@ class A10Client(object):
         return resp, status_code
 
     def activate_partition(self, partition):
-        url = "/axapi/v3/active-partition/{}"
+        url = "/axapi/v3/active-partition/"
         shared = "true" if partition == "shared" else "false"
         payload = {
             "active-partition": {
@@ -85,7 +85,7 @@ class A10Client(object):
         try:
             # Confirm partition exist first.
             # Otherwise sessions will switch and fail to logoff.
-            self.get('/axapi/v3/partition/' + partition)
+            self.post(url + partition)
             resp, status_code = self.post(url.format(partition), payload)
         except Exception as ex:
             raise Exception("Could not activate partition due to: {0}".format(ex))


### PR DESCRIPTION
Changed 'url' variable for activate_partition.  Wrong method used, changed to POST.  'url' variable not being utilized in request and had wrong axapi url.

## Description
If Feature Addition:
- Required: Related user story

If Bug Fix:
- Required: Severity Level (Low, High, Critical)
- Required: Issue Description

## Jira Ticket
**This is optional if you are an external contributor**
- Required: Add links to tickets closed here

## Connected SDK generator PR (Optional)
*Note: This is a private repository*

## Technical Approach
- Required: Overview of approach taken to solve the problem
- Optional: List of tasks completed w/ links 

## General Playbook Changes (Optional)

## Test Cases
- Required: List edge cases tested against in unit tests 

## Manual Testing
- Required: List of steps to manually test feature or fix 


---
- hosts: localhost
  connection: local
  tasks:
    - a10.acos_axapi.a10_slb_server:
        state: present
        ansible_host: 10.0.0.1
        ansible_username: admin
        ansible_password: a10
        ansible_port: 80
        a10_partition: dev
        name: ansibleTestServer
        host: 10.0.0.2
        action: enable
