### PR TITLE
Fix usage of inventory vars in normal plugin

### DIFF
--- a/plugins/action/normal.py
+++ b/plugins/action/normal.py
@@ -26,13 +26,22 @@ class ActionModule(ActionBase):
         self._append_module_args(module_args, required_args)
         return self._execute_module(task_vars=task_vars, module_args=module_args)
 
+    def _get_host_var(self, task_vars, name):
+        """ function returns templated variable by parsing inventory_file for given host
+        """
+        return self._templar.template(
+            task_vars.get(name),
+            convert_bare=True,
+            fail_on_undefined=True
+          )
+
     def _get_required_params(self, task_vars):
         """ function returns required argument by parsing inventory_file for given host
         """
-        ip = task_vars.get("ansible_host")
-        username = task_vars.get("ansible_username")
-        password = task_vars.get("ansible_password")
-        port = task_vars.get("ansible_port")
+        ip = self._get_host_var(task_vars, "ansible_host")
+        username = self._get_host_var(task_vars, "ansible_username")
+        password = self._get_host_var(task_vars, "ansible_password")
+        port = self._get_host_var(task_vars, "ansible_port")
 
         return ip, username, password, port
 


### PR DESCRIPTION
Unlike module arguments, templates in inventory variables won't be evaluated automatically. Therefore, their contents need to be parsed by the templar before usage.

## Description

Severity Level Low

If templates will be used in inventory variables related to this collection, these won't get parsed appropriately.

## Technical Approach

Unlike module arguments, templates in inventory variables won't be evaluated automatically. Therefore, their contents need to be parsed by the templar before usage.

## Test Cases

```yaml
ansible_host: 1.2.3.4
```

```yaml
foo: 1.2.3.4
ansible_host: '{{ foo }}'
```
